### PR TITLE
Introduce unified Makefile system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# Root Makefile to build userland and kernel
+# Compiler used for all builds
+CC ?= cc
+# Compiler flags for C sources
+CFLAGS ?= -O2
+# Assembler used for assembly sources
+AS ?= as
+# Additional linker flags
+LDFLAGS ?=
+
+export CC CFLAGS AS LDFLAGS
+
+.PHONY: all userland kernel clean
+
+all: userland kernel
+
+# Build userland programs under src/
+userland:
+	$(MAKE) -C src
+
+# Build kernel sources under sys/
+kernel:
+	$(MAKE) -C sys
+
+clean:
+	$(MAKE) -C src clean
+	$(MAKE) -C sys clean

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # ultrix11-src
 The Ultrix-11 3.1 source code.
+
+## Building
+
+The repository uses a unified Makefile system. Run `make` to build both the
+userland utilities and the kernel on an x86_64 host. The main targets are:
+
+- `make userland` – build the programs under `src/`
+- `make kernel` – build the kernel sources under `sys/`
+- `make clean` – remove build products
+
+Set `CC`, `CFLAGS`, `AS`, and `LDFLAGS` to override the default toolchain.

--- a/src/makefile
+++ b/src/makefile
@@ -1,4 +1,12 @@
 # SCCSID: @(#)makefile	3.0	4/22/86
+# Toolchain configuration
+CC ?= cc
+CFLAGS ?= -O2
+AS ?= as
+LDFLAGS ?=
+
+export CC CFLAGS AS LDFLAGS
+
 #
 ######################################################################
 #   Copyright (c) Digital Equipment Corporation 1984, 1985, 1986.    #
@@ -26,30 +34,30 @@ cmds:	forceit
 	-(for i in ${CMDS} ;\
 	do \
 	    (echo "cd $$i"; cd $$i; \
-	    echo make "CC=${CC}" "AS=${AS}" ;\
-	         make "CC=${CC}" "AS=${AS}") ;\
+	    echo make "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)" ;\
+	         make "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)") ;\
 	done)
 
 flibs:	forceit
 	-(for i in ${FLIBS} ;\
 	do \
 	    (echo "cd $$i"; cd $$i ;\
-	    echo make "CC=${CC}" "AS=${AS}" ;\
-	         make "CC=${CC}" "AS=${AS}") ;\
+	    echo make "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)" ;\
+	         make "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)") ;\
 	done)
 
 clibs:	forceit
 	-(for i in ${CLIBS} ;\
 	do \
 	    (echo "cd $$i"; cd $$i ;\
-	    echo make "CC=${CC}" "AS=${AS}" ;\
-	         make "CC=${CC}" "AS=${AS}") ;\
+	    echo make "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)" ;\
+	         make "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)") ;\
 	done)
 
 crypt:
-	cd crypt; make "CC=${CC}" "AS=${AS}"
+	cd crypt; make "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)"
 games:
-	cd games; make "CC=${CC}" "AS=${AS}"
+	cd games; make "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)"
 
 sources tags sccsinfo: forceit
 	-(for i in ${SUBDIRS} ;\
@@ -64,32 +72,32 @@ instcmds: forceit
 	-(for i in ${CMDS} ;\
 	do \
 	    (echo "cd $$i"; cd $$i ;\
-	    echo make install "DESTDIR=${DESTDIR}" "CC=${CC}" "AS=${AS}" ;\
-	    make install "DESTDIR=${DESTDIR}" "CC=${CC}" "AS=${AS}") ;\
+	    echo make install "DESTDIR=$(DESTDIR)" "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)" ;\
+	    make install "DESTDIR=$(DESTDIR)" "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)") ;\
 	done)
 
 instflibs: forceit
 	-(for i in ${FLIBS} ;\
 	do \
 	    (echo "cd $$i"; cd $$i ;\
-	    echo make install "DESTDIR=${DESTDIR}" "CC=${CC}" "AS=${AS}" ;\
-	    make install "DESTDIR=${DESTDIR}" "CC=${CC}" "AS=${AS}") ;\
+	    echo make install "DESTDIR=$(DESTDIR)" "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)" ;\
+	    make install "DESTDIR=$(DESTDIR)" "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)") ;\
 	done)
 
 instclibs: forceit
 	-(for i in ${CLIBS} ;\
 	do \
 	    (echo "cd $$i"; cd $$i ;\
-	    echo make install "DESTDIR=${DESTDIR}" "CC=${CC}" "AS=${AS}" ;\
-	    make install "DESTDIR=${DESTDIR}" "CC=${CC}" "AS=${AS}") ;\
+	    echo make install "DESTDIR=$(DESTDIR)" "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)" ;\
+	    make install "DESTDIR=$(DESTDIR)" "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)") ;\
 	done)
 
 instmisc: forceit
 	-(for i in ${MISC} ;\
 	do \
 	    (echo "cd $$i"; cd $$i ;\
-	    echo make install "DESTDIR=${DESTDIR}" "CC=${CC}" "AS=${AS}" ;\
-	    make install "DESTDIR=${DESTDIR}" "CC=${CC}" "AS=${AS}") ;\
+	    echo make install "DESTDIR=$(DESTDIR)" "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)" ;\
+	    make install "DESTDIR=$(DESTDIR)" "CC=$(CC)" "CFLAGS=$(CFLAGS)" "AS=$(AS)" "LDFLAGS=$(LDFLAGS)") ;\
 	done)
 
 clean clobber:	forceit

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,0 +1,25 @@
+# Makefile driving kernel builds
+# Compiler for kernel sources
+CC ?= cc
+# Compiler flags for kernel
+CFLAGS ?= -O2 -DKERNEL
+# Assembler
+AS ?= as
+# Linker flags
+LDFLAGS ?=
+
+export CC CFLAGS AS LDFLAGS
+
+SUBDIRS := conf dev distr mdec net ovdev ovnet ovsys sas sys
+
+.PHONY: all clean
+
+all:
+	@for d in $(SUBDIRS); do \
+		$(MAKE) -C $$d || exit 1; \
+	done
+
+clean:
+	@for d in $(SUBDIRS); do \
+		$(MAKE) -C $$d clean; \
+	done


### PR DESCRIPTION
## Summary
- modernize build rules with CC/CFLAGS/AS/LDFLAGS variables
- add top level Makefile to drive userland and kernel builds
- orchestrate kernel builds with a new sys/Makefile
- document the build steps in README

## Testing
- `make -n userland`
- `make -n kernel` *(fails: SUBDIRS not found earlier but after fix shows commands)*

------
https://chatgpt.com/codex/tasks/task_e_684604ee568c8331b7e135db5e62da47