### PR TITLE
Add docs build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDFLAGS ?=
 
 export CC CFLAGS AS LDFLAGS
 
-.PHONY: all userland kernel clean
+.PHONY: all userland kernel clean docs
 
 all: userland kernel
 
@@ -25,3 +25,10 @@ kernel:
 clean:
 	$(MAKE) -C src clean
 	$(MAKE) -C sys clean
+
+# Build project documentation using Doxygen and Sphinx
+docs:
+	# Generate API documentation via Doxygen
+	@doxygen docs/Doxyfile
+	# Build the HTML docs with Sphinx
+	@sphinx-build -b html docs/sphinx docs/sphinx/_build

--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ userland utilities and the kernel on an x86_64 host. The main targets are:
 - `make userland` – build the programs under `src/`
 - `make kernel` – build the kernel sources under `sys/`
 - `make clean` – remove build products
+- `make docs` – build the Doxygen and Sphinx documentation
 
 Set `CC`, `CFLAGS`, `AS`, and `LDFLAGS` to override the default toolchain.

--- a/README.md
+++ b/README.md
@@ -11,4 +11,7 @@ userland utilities and the kernel on an x86_64 host. The main targets are:
 - `make clean` – remove build products
 - `make docs` – build the Doxygen and Sphinx documentation
 
+Before running the above targets, execute `./setup.sh` to install the
+required build tools and Python packages.
+
 Set `CC`, `CFLAGS`, `AS`, and `LDFLAGS` to override the default toolchain.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Install dependencies for building the project and its documentation.
+# Prefers system packages via apt, then Python packages via pip,
+# and finally Node packages via npm if needed.
+set -e
+
+# Update package list and install apt dependencies
+sudo apt update
+sudo apt install -y \
+	doxygen \
+	graphviz \
+	python3-pip \
+	python3-sphinx
+
+# Install Python packages for Sphinx extensions
+python3 -m pip install --user --upgrade breathe
+
+# Placeholder for npm packages if future tooling requires them
+if command -v npm >/dev/null 2>&1; then
+	: # npm install <packages>
+fi


### PR DESCRIPTION
## Summary
- add `docs` phony target to run doxygen and sphinx
- mention docs target in build instructions

## Testing
- `make docs` *(fails: Could not import extension breathe)*

------
https://chatgpt.com/codex/tasks/task_e_68461331233c8331bc1feafb16945b49

## Summary by Sourcery

Introduce a `make docs` target to automate Doxygen and Sphinx documentation generation and update the README accordingly.

New Features:
- Introduce `docs` phony target in Makefile to build Doxygen and Sphinx documentation

Documentation:
- Mention the new `make docs` target in the README build instructions