### PR TITLE
Add documentation pages for build and emulator setup

### DIFF
--- a/docs/sphinx/build_steps.rst
+++ b/docs/sphinx/build_steps.rst
@@ -1,0 +1,41 @@
+Build Steps
+===========
+
+This section outlines how to compile the Ultrix-11 sources using the
+provided Makefiles.  The process assumes a modern Unix host with
+standard development tools.
+
+Prerequisites
+-------------
+
+Ensure a C compiler, assembler, and ``make`` are installed.  On Debian
+systems this can be done via
+
+.. code-block:: bash
+
+   sudo apt install build-essential
+
+Basic Build
+-----------
+
+Run ``make`` from the repository root to build everything:
+
+.. code-block:: bash
+
+   make
+
+The ``make`` target invokes ``userland`` and ``kernel`` builds.  To
+build only user programs or the kernel separately, use
+``make userland`` or ``make kernel``.
+
+Cleaning
+--------
+
+Temporary files can be removed with:
+
+.. code-block:: bash
+
+   make clean
+
+For more advanced configuration options see the top level
+``README.md``.

--- a/docs/sphinx/emulator_setup.rst
+++ b/docs/sphinx/emulator_setup.rst
@@ -1,0 +1,26 @@
+Emulator Setup
+==============
+
+The project relies on the SIMH emulator for running PDP-11 binaries.
+Detailed instructions are provided in ``docs/pdp11-lab.md`` which
+describes how to obtain SIMH and the operating system media.
+
+Quick Start
+-----------
+
+After installing SIMH, create a working directory:
+
+.. code-block:: bash
+
+   mkdir -p ~/pdp11
+   cd ~/pdp11
+
+Copy a configuration similar to ``2.11bsd.ini`` from the lab
+instructions.  Launch the emulator with:
+
+.. code-block:: bash
+
+   pdp11 2.11bsd.ini
+
+From this environment you can boot 2.11BSD or install Ultrix-11
+according to the steps in the lab guide.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -5,4 +5,7 @@ Ultrix-11 Documentation
    :maxdepth: 2
    :caption: Contents:
 
+   overview
+   build_steps
+   emulator_setup
    usage

--- a/docs/sphinx/overview.rst
+++ b/docs/sphinx/overview.rst
@@ -1,0 +1,19 @@
+Project Overview
+================
+
+This page provides a short overview of the Ultrix-11 source tree and
+its documentation.  The goal of the project is to preserve the
+original Ultrix-11 operating system while enabling modern build and
+emulation workflows.
+
+Source Layout
+-------------
+
+* ``src`` – userland utilities.
+* ``sys`` – kernel sources.
+* ``usr`` – user programs and libraries.
+* ``etc`` – configuration files and scripts.
+* ``docs`` – documentation for developers and users.
+
+The ``Makefile`` at the repository root coordinates building the
+sources.  See :doc:`build_steps` for detailed build instructions.


### PR DESCRIPTION
## Summary
- add overview, build_steps, and emulator_setup pages
- reference new pages in index

## Testing
- `sphinx-build -b html docs/sphinx docs/sphinx/_build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846137cf2f48331b16b1f4992abfca1