### PR TITLE
Add Doxygen annotations and track docs

### DIFF
--- a/docs/documentation_tracking.md
+++ b/docs/documentation_tracking.md
@@ -1,0 +1,4 @@
+# Documentation Tracking
+sys/net/if_uba.c
+src/cmd/ac.c
+src/cmd/lprsetup/printlib.c

--- a/src/cmd/ac.c
+++ b/src/cmd/ac.c
@@ -17,15 +17,18 @@ static char Sccsid[] = "@(#)ac.c 3.0 4/21/86";
 #include <sys/types.h>
 #include <sys/timeb.h>
 
-#define	TSIZE	33
-#define	USIZE	200
+/** Number of terminal slots to track. */
+#define TSIZE   33
 struct  utmp ibuf;
-
+/** Maximum number of user entries. */
+#define USIZE   200
+/** Accounting entry for a single user. */
 struct ubuf {
 	char	uname[8];
 	long	utime;
 } ubuf[USIZE];
 
+/** Per-terminal accounting totals. */
 struct tbuf {
 	struct	ubuf	*userp;
 	long	ttime;
@@ -40,6 +43,9 @@ long	day	= 86400L;
 int	pcount;
 char	**pptr;
 
+/**
+ * Program entry point.
+ */
 main(argc, argv) 
 char **argv;
 {
@@ -97,6 +103,9 @@ char **argv;
 	exit(0);
 }
 
+/**
+ * Process accounting records from the wtmp file.
+ */
 loop()
 {
 	register i;
@@ -142,6 +151,9 @@ loop()
 	update(tp, 0);
 }
 
+/**
+ * Display the accounting totals.
+ */
 print()
 {
 	int i;
@@ -165,6 +177,9 @@ print()
 	}
 }
 
+/**
+ * Update all per-terminal totals.
+ */
 upall(f)
 {
 	register struct tbuf *tp;
@@ -173,6 +188,9 @@ upall(f)
 		update(tp, f);
 }
 
+/**
+ * Update totals for a specific terminal.
+ */
 update(tp, f)
 struct tbuf *tp;
 {
@@ -208,6 +226,9 @@ struct tbuf *tp;
 	tp->userp = up;
 }
 
+/**
+ * Determine whether user index i is in the list of interest.
+ */
 among(i)
 {
 	register j, k;
@@ -228,6 +249,9 @@ among(i)
 	return(0);
 }
 
+/**
+ * Roll accounting totals over to a new day boundary.
+ */
 newday()
 {
 	long ttime;
@@ -245,6 +269,9 @@ newday()
 		midnight += day;
 }
 
+/**
+ * Print the date header when listing by day.
+ */
 pdate()
 {
 	long x;

--- a/src/cmd/lprsetup/printlib.c
+++ b/src/cmd/lprsetup/printlib.c
@@ -10,29 +10,31 @@
 /* Based on: (2.9BSD)	printcap.c	1.3	81/06/01	*/
 
 #ifndef BUFSIZ
-#define	BUFSIZ	512
+/** Buffer size used when none is defined. */
+#define BUFSIZ  512
 #endif
-
-#define MAXHOP	32	/* max number of tc= indirections */
+/** Maximum number of tc= indirections. */
+#define MAXHOP  32      /* max number of tc= indirections */
 
 #include	<ctype.h>
 #include	<whoami.h>
 #include	"local/uparm.h"
-/*
+/**
  * termcap - routines for dealing with the terminal capability data base
  *
- * TODO:	Should use a "last" pointer in tbuf, so that searching
- *		for capabilities alphabetically would not be a n**2/2
- *		process when large numbers of capabilities are given.
- * Note:	If we add a last pointer now we will screw up the
- *		tc capability. We really should compile termcap.
+ * @todo Should use a "last" pointer in tbuf, so that searching
+ *       for capabilities alphabetically would not be a n**2/2
+ *       process when large numbers of capabilities are given.
+ *       If we add a last pointer now we will screw up the tc capability.
+ *       We really should compile termcap.
  *
  * Essentially all the work here is scanning and decoding escapes
  * in string capabilities.  We don't use stdio because the editor
  * doesn't, and because living w/o it is not hard.
  */
 
-#define	PRINTCAP
+/** Compile in support for /etc/printcap. */
+#define PRINTCAP
 
 #ifdef	PRINTCAP
 #define	tgetent		pgetent
@@ -114,13 +116,13 @@ tgetent(bp, name)
 		}
 	}
 }
-
-/*
- * tnchktc: check the last entry, see if it's tc=xxx. If so,
- * recursively find xxx and append that entry (minus the names)
- * to take the place of the tc=xxx entry. This allows termcap
- * entries to say "like an HP2621 but doesn't turn on the labels".
- * Note that this works because of the left to right scan.
+/**
+ * Resolve tc= entries by recursively merging capabilities.
+ *
+ * This checks the last entry for a `tc=` field. If present,
+ * it recursively reads the referenced entry and appends its
+ * capabilities, replacing the `tc=` directive. This allows
+ * entries to reference other terminals with modifications.
  */
 tnchktc()
 {
@@ -168,6 +170,8 @@ tnchktc()
  * entry is a sequence of names separated by |'s, so we compare
  * against each such name.  The normal : terminator after the last
  * name (before the first field) stops us.
+/**
+ * Match a capability name against the names in the termcap entry.
  */
 tnamatch(np)
 	char *np;

--- a/sys/net/if_uba.c
+++ b/sys/net/if_uba.c
@@ -23,12 +23,10 @@
 
 #include <vaxif/if_uba.h>
 #include <sys/ubavar.h>
-
-/*
+/**
  * Routines supporting UNIBUS network interfaces.
  *
- * TODO:
- *	Support interfaces using only one BDP statically.
+ * @todo Support interfaces using only one BDP statically.
  */
 
 #if vax
@@ -39,6 +37,8 @@
  * doing this twice: once for reading and once for writing.  We also
  * allocate page frames in the mbuffer pool for these pages.
  * NOTE IT IS IMPLICITLY ASSUMED THAT hlen < PGSIZE
+/**
+ * Initialize a UNIBUS interface.
  */
 if_ubainit(ifu, uban, hlen, nmr)
 	register struct ifuba *ifu;
@@ -81,6 +81,9 @@ bad:
  * possibly a buffered data path, and initializing the fields of
  * the ifrw structure to minimize run-time overhead.
  */
+/**
+ * Allocate resources for a UNIBUS interface read/write structure.
+ */
 static
 if_ubaalloc(ifu, ifrw, nmr)
 	struct ifuba *ifu;
@@ -110,6 +113,9 @@ if_ubaalloc(ifu, ifrw, nmr)
  * data into mbufs.  When full cluster sized units are present
  * on the interface on cluster boundaries we can get them more
  * easily by remapping, and take advantage of this here.
+ */
+/**
+ * Retrieve a packet from the interface and build a chain of mbufs.
  */
 struct mbuf *
 if_rubaget(ifu, totlen, off0)
@@ -197,6 +203,8 @@ bad:
  * The argument chain of mbufs includes the local network
  * header which is copied to be in the mapped, aligned
  * i/o space.
+/**
+ * Map a chain of mbufs to the UNIBUS for transmission.
  */
 if_wubaput(ifu, m)
 	register struct ifuba *ifu;
@@ -363,14 +371,16 @@ if_wubaput(ifu, m)
 
 #ifdef	pdp11
 #ifdef	UNIBUS_MAP
-#define	KDSA	((u_short *) 0172360)
 struct ubmeter ub_meter;
-int	ub_wantmr;
+/** Address of the kernel data space map register. */
+#define KDSA    ((u_short *) 0172360)
 
 /*
  *	Map UNIBUS virtual memory over some address in kernel data
  *	space.  We're similar to the "mapalloc" routine used for
  *	raw I/O, but for different objects.
+/**
+ * Map kernel virtual memory to UNIBUS address space.
  */
 ubadr_t uballoc(ubanum, addr, size, x)
 int ubanum;	/* ignored for pdp11 */
@@ -423,6 +433,9 @@ unsigned size;
 /*
  *	Now for mapping an arbitrary piece of physical memory into
  *	UNIBUS virtual address space.
+ */
+/**
+ * Map physical memory into UNIBUS address space.
  */
 ubadr_t ubmalloc(ubanum, addr, size, x)
 int ubanum;	/* unused on pdp11 */


### PR DESCRIPTION
## Summary
- document UNIBUS network interface helpers
- annotate accounting utility
- annotate printcap library
- begin documentation tracking list

## Testing
- `make -n` *(fails: No rule to make target '../sys/LIB1_id', needed by 'kernel_id')*

------
https://chatgpt.com/codex/tasks/task_e_684613391ab08331b7b575dbc660ab52

## Summary by Sourcery

Annotate core modules with Doxygen comments and add a documentation tracking list.

Enhancements:
- Add Doxygen annotations to printcap library (printlib.c)
- Add Doxygen annotations to accounting utility (ac.c)
- Add Doxygen annotations to UNIBUS network interface code (if_uba.c)

Documentation:
- Introduce docs/documentation_tracking.md to track annotated files