### PR TITLE
Refine agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Contributor Guidelines
+
+This repository requires strict documentation and code formatting standards.
+All contributions should meet a PhD-level engineering standard for clarity and completeness.
+
+## Documentation
+
+- Every source file in `src/` and `sys/` **must** contain Doxygen-style
+  comments for all functions, data structures, and global variables.
+- When adding or modifying code, ensure the new or updated documentation
+  passes `doxygen docs/Doxyfile` without warnings.
+- The Sphinx manual under `docs/sphinx` should be kept in sync with the
+  source code. Update reStructuredText files whenever public APIs change.
+- Code lacking Doxygen comments should be brought up to compliance. Use
+  `///` or `/** ... */` style annotations.
+- While updating documentation, clearly highlight and comment any
+  `TODO`, `PLACEHOLDER`, `FIXME`, `CRITICAL_BUG`, or `STUB` markers within
+  the source. These notations should be easy to find in generated
+  documentation and accompanied by an explanation of the outstanding work.
+
+## Formatting
+
+- Code must be formatted with `clang-format` using the style defined in
+  `.clang-format` if present, or LLVM style as a default. Run
+  `clang-format -i` on every modified C source/header file before
+  committing.
+- Formatting should only affect code, not surrounding comments.
+- All code should compile cleanly with `-Wall -Wextra` and no warnings.
+
+## Review Expectations
+
+- Pull requests will be reviewed for thorough Doxygen coverage and modern
+  formatting. Documentation and code quality should meet professional
+  engineering standards.
+- Run `make` and the documentation build steps (`doxygen` and Sphinx) to
+  ensure no errors prior to submission.


### PR DESCRIPTION
## Summary
- update contributor guide to highlight TODO/FIXME markers

## Testing
- `make` *(fails: header and prototype issues)*
- `doxygen docs/Doxyfile` *(warnings about missing files and dot errors)*
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`

------
https://chatgpt.com/codex/tasks/task_e_684614e9a2e4833197497d67bf0cca0a

## Summary by Sourcery

Introduce a new contributor guidelines document outlining strict documentation, formatting, and review standards for the repository.

New Features:
- Add AGENTS.md with detailed contributor guidelines

Enhancements:
- Require Doxygen comments in source files and passing of doxygen builds without warnings
- Enforce synchronization of Sphinx documentation with public API changes
- Mandate highlighting of TODO/FIXME and similar markers in generated documentation
- Enforce clang-format styling and compilation with no warnings