### PR TITLE
Add Sphinx pages for repo overview and build workflow

### DIFF
--- a/docs/sphinx/build_workflow.rst
+++ b/docs/sphinx/build_workflow.rst
@@ -1,0 +1,20 @@
+Build Workflow
+==============
+
+This page explains the make-based workflow used to compile Ultrix-11.
+
+Targets
+-------
+
+* ``make`` – build user programs and the kernel.
+* ``make userland`` – build only the userland sources under ``src``.
+* ``make kernel`` – build the kernel located in ``sys``.
+* ``make clean`` – remove build artifacts.
+
+Cross Compilation
+-----------------
+
+Set ``CC``, ``CFLAGS``, ``AS``, and ``LDFLAGS`` to use a cross compiler or
+custom toolchain when invoking ``make``.
+
+For a step-by-step guide see :doc:`build_steps`.

--- a/docs/sphinx/emulator_lab.rst
+++ b/docs/sphinx/emulator_lab.rst
@@ -1,0 +1,38 @@
+Emulator Lab Setup
+==================
+
+The full emulator instructions reside in ``../pdp11-lab.md``.  This page
+summarizes the key steps for preparing a SIMH environment.
+
+Prerequisites
+-------------
+
+.. code-block:: bash
+
+   sudo apt update
+   sudo apt install --yes software-properties-common
+   sudo add-apt-repository universe
+   sudo add-apt-repository multiverse
+   sudo apt install --yes simh
+
+Fetching Media
+--------------
+
+.. code-block:: bash
+
+   mkdir -p ~/pdp11/images
+   cd ~/pdp11/images
+   curl -L -O https://chasecovello.com/2.11BSD_rq.dsk.xz
+   xz -dv 2.11BSD_rq.dsk.xz
+   curl -L -O https://www.tuhs.org/Archive/Distributions/DEC/Ultrix-11/3.1/ultrix-11.tap.gz
+   gunzip ultrix-11.tap.gz
+
+Running
+-------
+
+.. code-block:: bash
+
+   cd ~/pdp11
+   pdp11 2.11bsd.ini
+
+The ``scripts/setup_lab.sh`` helper automates these steps.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -6,6 +6,9 @@ Ultrix-11 Documentation
    :caption: Contents:
 
    overview
+   repository_overview
    build_steps
+   build_workflow
    emulator_setup
+   emulator_lab
    usage

--- a/docs/sphinx/repository_overview.rst
+++ b/docs/sphinx/repository_overview.rst
@@ -1,0 +1,25 @@
+Repository Overview
+===================
+
+This page describes the layout of the Ultrix-11 source tree and its key files.
+
+Directories
+-----------
+
+* ``src`` – userland utilities.
+* ``sys`` – kernel sources.
+* ``usr`` – user programs and libraries.
+* ``etc`` – configuration files and scripts.
+* ``docs`` – documentation for developers and users.
+
+Top-Level Build
+---------------
+
+A ``Makefile`` at the repository root coordinates building the sources.
+The accompanying ``README.md`` provides quick build instructions.
+
+License
+-------
+
+Original DEC licensing terms are found in the ``COPYRIGHT`` file. The
+source is provided solely for historical study.


### PR DESCRIPTION
## Summary
- document repository layout
- describe the build workflow
- add an emulator lab quick-start
- include new pages in the Sphinx toctree

## Testing
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`

------
https://chatgpt.com/codex/tasks/task_e_68461632ea908331b5ea208fcbcf68f5