### PR TITLE
Add minimal x86_64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ CFLAGS ?= -O2
 AS ?= as
 # Additional linker flags
 LDFLAGS ?=
+ARCH ?= x86_64_v1
 
-export CC CFLAGS AS LDFLAGS
+export CC CFLAGS AS LDFLAGS ARCH
 
 .PHONY: all userland kernel clean docs
 
@@ -20,11 +21,11 @@ userland:
 
 # Build kernel sources under sys/
 kernel:
-	$(MAKE) -C sys
+	$(MAKE) -C sys ARCH=$(ARCH)
 
 clean:
 	$(MAKE) -C src clean
-	$(MAKE) -C sys clean
+	$(MAKE) -C sys clean ARCH=$(ARCH)
 
 # Build project documentation using Doxygen and Sphinx
 docs:

--- a/docs/sphinx/arch_x86_64_v1.rst
+++ b/docs/sphinx/arch_x86_64_v1.rst
@@ -1,0 +1,14 @@
+x86_64_v1 Architecture
+=====================
+
+The ``sys/arch/x86_64_v1`` directory contains experimental sources for
+bringing Ultrix-11 to a 64-bit environment.  The code is intentionally
+minimal and currently provides:
+
+* ``boot.s`` – a very small bootstrap that jumps to ``kernel_main``.
+* ``interrupts.s`` – a table of interrupt stubs that branch to a common
+  handler.
+* ``asm.h`` – helper macros used by the assembly sources.
+
+These files are compiled into ``libarch.a`` and linked when building the
+kernel with ``ARCH=x86_64_v1``.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -12,3 +12,4 @@ Ultrix-11 Documentation
    emulator_setup
    emulator_lab
    usage
+   arch_x86_64_v1

--- a/docs/sphinx/overview.rst
+++ b/docs/sphinx/overview.rst
@@ -14,6 +14,7 @@ Source Layout
 * ``usr`` – user programs and libraries.
 * ``etc`` – configuration files and scripts.
 * ``docs`` – documentation for developers and users.
+* ``sys/arch/x86_64_v1`` – experimental 64-bit architecture support.
 
 The ``Makefile`` at the repository root coordinates building the
 sources.  See :doc:`build_steps` for detailed build instructions.

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -7,19 +7,24 @@ CFLAGS ?= -O2 -DKERNEL
 AS ?= as
 # Linker flags
 LDFLAGS ?=
+# Target architecture (default PDP-11)
+ARCH ?= pdp11
 
 export CC CFLAGS AS LDFLAGS
 
 SUBDIRS := conf dev distr mdec net ovdev ovnet ovsys sas sys
+ifeq ($(ARCH),x86_64_v1)
+SUBDIRS += arch/x86_64_v1
+endif
 
 .PHONY: all clean
 
 all:
-	@for d in $(SUBDIRS); do \
-		$(MAKE) -C $$d || exit 1; \
-	done
+        @for d in $(SUBDIRS); do \
+                $(MAKE) -C $$d ARCH=$(ARCH) || exit 1; \
+        done
 
 clean:
-	@for d in $(SUBDIRS); do \
-		$(MAKE) -C $$d clean; \
-	done
+        @for d in $(SUBDIRS); do \
+                $(MAKE) -C $$d clean ARCH=$(ARCH); \
+        done

--- a/sys/arch/x86_64_v1/Makefile
+++ b/sys/arch/x86_64_v1/Makefile
@@ -1,0 +1,24 @@
+# Makefile for x86_64_v1 architecture
+#
+# Builds a small library with boot code and interrupt stubs.
+
+ARCHIVE = libarch.a
+OBJECTS = boot.o interrupts.o
+
+CFLAGS ?= -O2 -DKERNEL -m64
+ASFLAGS ?= -m64
+
+all: $(ARCHIVE)
+
+$(ARCHIVE): $(OBJECTS)
+@rm -f $(ARCHIVE)
+ar cr $(ARCHIVE) $(OBJECTS)
+
+boot.o: boot.s
+$(AS) $(ASFLAGS) -o $@ $<
+
+interrupts.o: interrupts.s
+$(AS) $(ASFLAGS) -o $@ $<
+
+clean:
+@rm -f $(OBJECTS) $(ARCHIVE)

--- a/sys/arch/x86_64_v1/asm.h
+++ b/sys/arch/x86_64_v1/asm.h
@@ -1,0 +1,11 @@
+/**
+ * @file asm.h
+ * @brief Helper macros for low-level x86_64 assembly.
+ */
+#ifndef X86_64_V1_ASM_H
+#define X86_64_V1_ASM_H
+
+/** Halt the CPU. */
+#define HALT() __asm__("hlt")
+
+#endif /* X86_64_V1_ASM_H */

--- a/sys/arch/x86_64_v1/boot.s
+++ b/sys/arch/x86_64_v1/boot.s
@@ -1,0 +1,14 @@
+/**
+ * @file boot.s
+ * @brief Minimal x86_64 bootstrap stub.
+ *
+ * This placeholder simply jumps to `kernel_main` after disabling
+ * interrupts. It halts the processor if `kernel_main` returns.
+ */
+.globl _start
+_start:
+    cli                     # disable interrupts
+    call kernel_main        # jump to kernel entry
+1:
+    hlt                     # halt CPU
+    jmp 1b                  # loop forever

--- a/sys/arch/x86_64_v1/interrupts.s
+++ b/sys/arch/x86_64_v1/interrupts.s
@@ -1,0 +1,17 @@
+/**
+ * @file interrupts.s
+ * @brief Interrupt vector stubs for x86_64.
+ *
+ * Each entry in `int_stub_table` jumps to the common handler
+ * `int_common`. This code is only a placeholder for real
+ * interrupt handling logic.
+ */
+.globl int_stub_table
+int_stub_table:
+    .rept 256
+    .quad int_common
+    .endr
+
+.globl int_common
+int_common:
+    iretq


### PR DESCRIPTION
## Summary
- add experimental `sys/arch/x86_64_v1` with bootstrap code
- include new architecture in kernel Makefiles
- document the architecture in Sphinx docs

## Testing
- `make` *(fails: build errors)*
- `doxygen docs/Doxyfile` *(fails: command not found)*
- `sphinx-build -b html docs/sphinx docs/sphinx/_build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461a6346288331bbe92986d871a9c2