### PR TITLE
Add Sphinx static directory

### DIFF
--- a/docs/sphinx/_static/custom.css
+++ b/docs/sphinx/_static/custom.css
@@ -1,0 +1,6 @@
+/*
+ * Custom styling for Ultrix-11 Sphinx documentation.
+ */
+body {
+    font-size: 1.05em;
+}

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -18,7 +18,7 @@ extensions = [
 
 # Breathe configuration links Sphinx to the Doxygen XML output
 breathe_projects = {
-    "Ultrix-11": str(Path(__file__).resolve().parents[2] / "docs" / "doxygen" / "xml")
+    "Ultrix-11": Path(__file__).resolve().parents[2] / "docs" / "doxygen" / "xml"
 }
 breathe_default_project = "Ultrix-11"
 
@@ -28,3 +28,7 @@ exclude_patterns = []
 # HTML output options
 html_theme = "alabaster"
 html_static_path = ["_static"]
+
+def setup(app):
+    """Hook to include project customizations."""
+    app.add_css_file("custom.css")


### PR DESCRIPTION
## Summary
- add a `_static` directory with a simple CSS file
- register the stylesheet in Sphinx configuration

## Testing
- `make` *(fails: cc ... Error)*
- `doxygen docs/Doxyfile` *(shows many warnings)*
- `/root/.pyenv/versions/3.12.10/bin/sphinx-build -b html docs/sphinx docs/sphinx/_build`

------
https://chatgpt.com/codex/tasks/task_e_68461a4dc8ac8331bba0cd9207daf257