### PR TITLE
Add ARCH variable and x86_64 build stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,14 @@
 CC ?= cc
 # Compiler flags for C sources
 CFLAGS ?= -O2
+# Target architecture (defaults to PDP-11 for historical builds)
+ARCH ?= pdp11
 # Assembler used for assembly sources
 AS ?= as
 # Additional linker flags
 LDFLAGS ?=
 
-export CC CFLAGS AS LDFLAGS
+export CC CFLAGS AS LDFLAGS ARCH
 
 .PHONY: all userland kernel clean docs
 
@@ -16,15 +18,17 @@ all: userland kernel
 
 # Build userland programs under src/
 userland:
-	$(MAKE) -C src
+	# Propagate target architecture to the userland build
+	$(MAKE) -C src ARCH=$(ARCH)
 
 # Build kernel sources under sys/
 kernel:
-	$(MAKE) -C sys
+	# Propagate target architecture to the kernel build
+	$(MAKE) -C sys ARCH=$(ARCH)
 
 clean:
-	$(MAKE) -C src clean
-	$(MAKE) -C sys clean
+	$(MAKE) -C src clean ARCH=$(ARCH)
+	$(MAKE) -C sys clean ARCH=$(ARCH)
 
 # Build project documentation using Doxygen and Sphinx
 docs:

--- a/docs/sphinx/build_steps.rst
+++ b/docs/sphinx/build_steps.rst
@@ -28,6 +28,14 @@ The ``make`` target invokes ``userland`` and ``kernel`` builds.  To
 build only user programs or the kernel separately, use
 ``make userland`` or ``make kernel``.
 
+An ``ARCH`` variable controls the target architecture.  It defaults to
+``pdp11``.  To build the experimental 64-bit kernel, pass
+``ARCH=x86_64_v1`` on the command line:
+
+.. code-block:: bash
+
+   make ARCH=x86_64_v1
+
 Cleaning
 --------
 

--- a/src/makefile
+++ b/src/makefile
@@ -4,8 +4,10 @@ CC ?= cc
 CFLAGS ?= -O2
 AS ?= as
 LDFLAGS ?=
+# Target architecture passed from the root Makefile
+ARCH ?= pdp11
 
-export CC CFLAGS AS LDFLAGS
+export CC CFLAGS AS LDFLAGS ARCH
 
 #
 ######################################################################

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -7,19 +7,31 @@ CFLAGS ?= -O2 -DKERNEL
 AS ?= as
 # Linker flags
 LDFLAGS ?=
+# Target architecture (defaults to PDP-11)
+ARCH ?= pdp11
 
-export CC CFLAGS AS LDFLAGS
+export CC CFLAGS AS LDFLAGS ARCH
 
 SUBDIRS := conf dev distr mdec net ovdev ovnet ovsys sas sys
 
 .PHONY: all clean
 
+# Default PDP-11 build steps
+ifeq ($(ARCH),pdp11)
 all:
-	@for d in $(SUBDIRS); do \
-		$(MAKE) -C $$d || exit 1; \
-	done
+       @for d in $(SUBDIRS); do \
+               $(MAKE) -C $$d ARCH=$(ARCH) || exit 1; \
+       done
 
 clean:
-	@for d in $(SUBDIRS); do \
-		$(MAKE) -C $$d clean; \
-	done
+       @for d in $(SUBDIRS); do \
+               $(MAKE) -C $$d clean ARCH=$(ARCH); \
+       done
+else
+# Delegate to architecture-specific directory
+all:
+       $(MAKE) -C arch/$(ARCH) ARCH=$(ARCH)
+
+clean:
+       $(MAKE) -C arch/$(ARCH) clean ARCH=$(ARCH)
+endif

--- a/sys/arch/x86_64_v1/Makefile
+++ b/sys/arch/x86_64_v1/Makefile
@@ -1,0 +1,19 @@
+# Makefile for the x86_64_v1 kernel build
+CC ?= cc
+CFLAGS ?= -O2 -DKERNEL -m64
+AS ?= as
+LDFLAGS ?=
+
+export CC CFLAGS AS LDFLAGS ARCH
+
+.PHONY: all clean
+
+# Build the placeholder kernel
+all:
+@echo "Building kernel for $(ARCH)" # notify architecture
+$(CC) $(CFLAGS) -c stub.c -o stub.o # compile stub
+$(CC) $(LDFLAGS) stub.o -o kernel-$(ARCH) # link kernel
+
+# Remove generated files
+clean:
+rm -f stub.o kernel-$(ARCH)

--- a/sys/arch/x86_64_v1/stub.c
+++ b/sys/arch/x86_64_v1/stub.c
@@ -1,0 +1,14 @@
+/**
+ * @file stub.c
+ * @brief Minimal kernel entry point for x86_64_v1.
+ */
+
+/**
+ * @brief Entry function for the placeholder kernel.
+ *
+ * This stub does nothing beyond returning success. It serves as a
+ * demonstration target for the build system.
+ *
+ * @return always 0.
+ */
+int main(void) { return 0; /* successful placeholder */ }


### PR DESCRIPTION
## Summary
- add an `ARCH` variable to the root Makefile
- propagate `ARCH` into src and sys builds
- allow sys/Makefile to delegate to architecture-specific directories
- provide a stub kernel for `x86_64_v1`
- document the new `ARCH` build flag

## Testing
- `doxygen docs/Doxyfile` *(fails: warnings present)*
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`
- `make ARCH=x86_64_v1` *(fails to compile legacy sources)*

------
https://chatgpt.com/codex/tasks/task_e_68461a72cc2c83318ccde2f2e080b40f

## Summary by Sourcery

Introduce a configurable ARCH variable for multi-architecture support, update Makefiles to propagate this flag and delegate kernel builds to architecture-specific directories, and add a minimal x86_64_v1 stub kernel build.

New Features:
- Introduce ARCH variable in root, src, and sys Makefiles to select target architecture
- Delegate sys build to arch/$(ARCH) directory when ARCH≠pdp11
- Add a minimal placeholder kernel stub and build rules for the x86_64_v1 architecture

Enhancements:
- Propagate ARCH flag into sub-makes for consistent architecture handling

Documentation:
- Document the new ARCH build flag in the Sphinx build steps