### PR TITLE
Add x86_64 architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,15 @@ All contributions should meet a PhD-level engineering standard for clarity and c
 - Formatting should only affect code, not surrounding comments.
 - All code should compile cleanly with `-Wall -Wextra` and no warnings.
 
+## Build System
+
+All architectures **must** provide a recursive CMake build that mirrors the
+traditional Makefile targets. The CMake configuration should launch via the
+existing top-level `make` entry points so legacy workflows continue to
+function. Maintain the CMake rules in parallel with the historical Makefiles
+and keep them consistent across platforms, including the `arch_x86_64_v1`
+port.
+
 ## Review Expectations
 
 - Pull requests will be reviewed for thorough Doxygen coverage and modern

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ userland utilities and the kernel on an x86_64 host. The main targets are:
 - `make clean` – remove build products
 - `make docs` – build the Doxygen and Sphinx documentation
 
+Experimental support for an `arch_x86_64_v1` build is available. Details
+are documented in `docs/sphinx/arch_x86_64_v1.rst`.
+
 Before running the above targets, execute `./setup.sh` to install the
 required build tools and Python packages.
 

--- a/docs/sphinx/arch_x86_64_v1.rst
+++ b/docs/sphinx/arch_x86_64_v1.rst
@@ -1,0 +1,38 @@
+Architecture: x86_64 v1
+=======================
+
+This document outlines the build prerequisites for the experimental
+``arch_x86_64_v1`` port, describes the system layout for this target and
+summarizes how it differs from the classic PDP-11 environment.
+
+Prerequisites
+-------------
+
+* A modern 64-bit Linux distribution with ``gcc``, ``make`` and
+  ``binutils`` installed.
+* Python 3.10 or newer with the ``breathe`` and ``sphinx`` packages.
+* ``doxygen`` for generating API documentation.
+
+Layout
+------
+
+The ``arch_x86_64_v1`` directory mirrors the traditional layout used for
+PDP-11 sources:
+
+* ``src`` – userland utilities compiled for ``x86_64``.
+* ``sys`` – kernel sources targeting the new architecture.
+* ``usr`` and ``etc`` retain their original roles for system libraries and
+  configuration files.
+
+Differences from PDP-11
+-----------------------
+
+* 64-bit pointers and word sizes require updates to many legacy data
+  structures.
+* The boot process uses the standard ``grub`` loader rather than PDP-11
+  boot ROMs.
+* Endianness is little-endian instead of the PDP-11's native byte order.
+
+This port is very early in development. See :doc:`build_steps` for how to
+invoke the build system. The root ``README.md`` provides additional
+context and links to emulator notes.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -9,6 +9,7 @@ Ultrix-11 Documentation
    repository_overview
    build_steps
    build_workflow
+   arch_x86_64_v1
    emulator_setup
    emulator_lab
    usage


### PR DESCRIPTION
## Summary
- document arch_x86_64_v1 architecture
- mention new port in README build section
- include new page in Sphinx table of contents
- specify that all architectures require a parallel CMake build

## Testing
- `make` *(fails: implicit function declarations and build errors)*
- `doxygen docs/Doxyfile` *(fails: command not found)*
- `sphinx-build -b html docs/sphinx docs/sphinx/_build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461a6b40e483319c706ee424789af1

## Summary by Sourcery

Document and integrate the new `arch_x86_64_v1` port by adding Sphinx documentation and README references, and enforce parallel CMake builds alongside Makefiles for all architectures.

Enhancements:
- Require all architectures to maintain a recursive CMake build that mirrors existing Makefile targets, as specified in AGENTS.md.

Documentation:
- Add a new Sphinx page for the `arch_x86_64_v1` architecture and include it in the table of contents.
- Mention experimental support for `arch_x86_64_v1` in the README build section.