### PR TITLE
Add minimal Doxygen comments to utilities

### DIFF
--- a/src/cmd/accton.c
+++ b/src/cmd/accton.c
@@ -4,19 +4,28 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file accton.c
+ * @brief Enable or disable system accounting.
+ */
 
 static char Sccsid[] = "@(#)accton.c 3.0 4/21/86";
-main(argc, argv)
-char **argv;
-{
-	extern errno;
-	if (argc > 1)
-		acct(argv[1]);
-	else
-		acct((char *)0);
-	if (errno) {
-		perror("accton");
-		exit(1);
-	}
-	exit(0);
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  extern errno;
+  if (argc > 1)
+    acct(argv[1]);
+  else
+    acct((char *)0);
+  if (errno) {
+    perror("accton");
+    exit(1);
+  }
+  exit(0);
 }

--- a/src/cmd/ar.c
+++ b/src/cmd/ar.c
@@ -4,710 +4,681 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file ar.c
+ * @brief Archive utility.
+ */
 
 static char Sccsid[] = "@(#)ar.c 3.0 4/21/86";
-#include <stdio.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <ar.h>
 #include <signal.h>
-struct	stat	stbuf;
-struct	ar_hdr	arbuf;
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+struct stat stbuf;
+struct ar_hdr arbuf;
 
-#define	SKIP	1
-#define	IODD	2
-#define	OODD	4
-#define	HEAD	8
+#define SKIP 1
+#define IODD 2
+#define OODD 4
+#define HEAD 8
 
-char	*man	=	{ "mrxtdpq" };
-char	*opt	=	{ "uvnbail" };
+char *man = {"mrxtdpq"};
+char *opt = {"uvnbail"};
 
-int	signum[] = {SIGHUP, SIGINT, SIGQUIT, 0};
-int	sigdone();
-long	lseek();
-int	rcmd();
-int	dcmd();
-int	xcmd();
-int	tcmd();
-int	pcmd();
-int	mcmd();
-int	qcmd();
-int	(*comfun)();
-char	flg[26];
-char	**namv;
-int	namc;
-char	*arnam;
-char	*ponam;
-char	*tmp0nam	=	{ "/tmp/vXXXXX" };
-char	*tmp1nam	=	{ "/tmp/v1XXXXX" };
-char	*tmp2nam	=	{ "/tmp/v2XXXXX" };
-char	*tfnam;
-char	*tf1nam;
-char	*tf2nam;
-char	*file;
-char	name[16];
-int	af;
-int	tf;
-int	tf1;
-int	tf2;
-int	qf;
-int	bastate;
-char	buf[1024];
+int signum[] = {SIGHUP, SIGINT, SIGQUIT, 0};
+int sigdone();
+long lseek();
+int rcmd();
+int dcmd();
+int xcmd();
+int tcmd();
+int pcmd();
+int mcmd();
+int qcmd();
+int (*comfun)();
+char flg[26];
+char **namv;
+int namc;
+char *arnam;
+char *ponam;
+char *tmp0nam = {"/tmp/vXXXXX"};
+char *tmp1nam = {"/tmp/v1XXXXX"};
+char *tmp2nam = {"/tmp/v2XXXXX"};
+char *tfnam;
+char *tf1nam;
+char *tf2nam;
+char *file;
+char name[16];
+int af;
+int tf;
+int tf1;
+int tf2;
+int qf;
+int bastate;
+char buf[1024];
 
-char	*trim();
-char	*mktemp();
-char	*ctime();
+char *trim();
+char *mktemp();
+char *ctime();
 
-main(argc, argv)
-char *argv[];
-{
-	register i;
-	register char *cp;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  register i;
+  register char *cp;
 
-	for(i=0; signum[i]; i++)
-		if(signal(signum[i], SIG_IGN) != SIG_IGN)
-			signal(signum[i], sigdone);
-	if(argc < 3)
-		usage();
-	cp = argv[1];
-	for(cp = argv[1]; *cp; cp++)
-	switch(*cp) {
-	case 'l':
-	case 'v':
-	case 'u':
-	case 'n':
-	case 'a':
-	case 'b':
-	case 'c':
-	case 'i':
-		flg[*cp - 'a']++;
-		continue;
+  for (i = 0; signum[i]; i++)
+    if (signal(signum[i], SIG_IGN) != SIG_IGN)
+      signal(signum[i], sigdone);
+  if (argc < 3)
+    usage();
+  cp = argv[1];
+  for (cp = argv[1]; *cp; cp++)
+    switch (*cp) {
+    case 'l':
+    case 'v':
+    case 'u':
+    case 'n':
+    case 'a':
+    case 'b':
+    case 'c':
+    case 'i':
+      flg[*cp - 'a']++;
+      continue;
 
-	case 'r':
-		setcom(rcmd);
-		continue;
+    case 'r':
+      setcom(rcmd);
+      continue;
 
-	case 'd':
-		setcom(dcmd);
-		continue;
+    case 'd':
+      setcom(dcmd);
+      continue;
 
-	case 'x':
-		setcom(xcmd);
-		continue;
+    case 'x':
+      setcom(xcmd);
+      continue;
 
-	case 't':
-		setcom(tcmd);
-		continue;
+    case 't':
+      setcom(tcmd);
+      continue;
 
-	case 'p':
-		setcom(pcmd);
-		continue;
+    case 'p':
+      setcom(pcmd);
+      continue;
 
-	case 'm':
-		setcom(mcmd);
-		continue;
+    case 'm':
+      setcom(mcmd);
+      continue;
 
-	case 'q':
-		setcom(qcmd);
-		continue;
+    case 'q':
+      setcom(qcmd);
+      continue;
 
-	default:
-		fprintf(stderr, "ar: bad option `%c'\n", *cp);
-		done(1);
-	}
-	if(flg['l'-'a']) {
-		tmp0nam = "vXXXXX";
-		tmp1nam = "v1XXXXX";
-		tmp2nam = "v2XXXXX";
-		}
-	if(flg['i'-'a'])
-		flg['b'-'a']++;
-	if(flg['a'-'a'] || flg['b'-'a']) {
-		bastate = 1;
-		ponam = trim(argv[2]);
-		argv++;
-		argc--;
-		if(argc < 3)
-			usage();
-	}
-	arnam = argv[2];
-	namv = argv+3;
-	namc = argc-3;
-	if(comfun == 0) {
-		if(flg['u'-'a'] == 0) {
-			fprintf(stderr, "ar: one of [%s] must be specified\n", man);
-			done(1);
-		}
-		setcom(rcmd);
-	}
-	(*comfun)();
-	done(notfound());
+    default:
+      fprintf(stderr, "ar: bad option `%c'\n", *cp);
+      done(1);
+    }
+  if (flg['l' - 'a']) {
+    tmp0nam = "vXXXXX";
+    tmp1nam = "v1XXXXX";
+    tmp2nam = "v2XXXXX";
+  }
+  if (flg['i' - 'a'])
+    flg['b' - 'a']++;
+  if (flg['a' - 'a'] || flg['b' - 'a']) {
+    bastate = 1;
+    ponam = trim(argv[2]);
+    argv++;
+    argc--;
+    if (argc < 3)
+      usage();
+  }
+  arnam = argv[2];
+  namv = argv + 3;
+  namc = argc - 3;
+  if (comfun == 0) {
+    if (flg['u' - 'a'] == 0) {
+      fprintf(stderr, "ar: one of [%s] must be specified\n", man);
+      done(1);
+    }
+    setcom(rcmd);
+  }
+  (*comfun)();
+  done(notfound());
 }
 
-setcom(fun)
-int (*fun)();
+setcom(fun) int (*fun)();
 {
 
-	if(comfun != 0) {
-		fprintf(stderr, "ar: only one of [%s] allowed\n", man);
-		done(1);
-	}
-	comfun = fun;
+  if (comfun != 0) {
+    fprintf(stderr, "ar: only one of [%s] allowed\n", man);
+    done(1);
+  }
+  comfun = fun;
 }
 
-rcmd()
-{
-	register f;
+rcmd() {
+  register f;
 
-	init();
-	getaf();
-	while(!getdir()) {
-		bamatch();
-		if(namc == 0 || match()) {
-			f = stats();
-			if(f < 0) {
-				if(namc)
-					fprintf(stderr, "ar: cannot open %s\n", file);
-				goto cp;
-			}
-			if(flg['u'-'a'])
-				if(stbuf.st_mtime <= arbuf.ar_date) {
-					close(f);
-					goto cp;
-				}
-			mesg('r');
-			copyfil(af, -1, IODD+SKIP);
-			movefil(f);
-			continue;
-		}
-	cp:
-		mesg('c');
-		copyfil(af, tf, IODD+OODD+HEAD);
-	}
-	cleanup();
+  init();
+  getaf();
+  while (!getdir()) {
+    bamatch();
+    if (namc == 0 || match()) {
+      f = stats();
+      if (f < 0) {
+        if (namc)
+          fprintf(stderr, "ar: cannot open %s\n", file);
+        goto cp;
+      }
+      if (flg['u' - 'a'])
+        if (stbuf.st_mtime <= arbuf.ar_date) {
+          close(f);
+          goto cp;
+        }
+      mesg('r');
+      copyfil(af, -1, IODD + SKIP);
+      movefil(f);
+      continue;
+    }
+  cp:
+    mesg('c');
+    copyfil(af, tf, IODD + OODD + HEAD);
+  }
+  cleanup();
 }
 
-dcmd()
-{
+dcmd() {
 
-	init();
-	if(getaf())
-		noar();
-	while(!getdir()) {
-		if(match()) {
-			mesg('d');
-			copyfil(af, -1, IODD+SKIP);
-			continue;
-		}
-		mesg('c');
-		copyfil(af, tf, IODD+OODD+HEAD);
-	}
-	install();
+  init();
+  if (getaf())
+    noar();
+  while (!getdir()) {
+    if (match()) {
+      mesg('d');
+      copyfil(af, -1, IODD + SKIP);
+      continue;
+    }
+    mesg('c');
+    copyfil(af, tf, IODD + OODD + HEAD);
+  }
+  install();
 }
 
-xcmd()
-{
-	register f;
+xcmd() {
+  register f;
 
-	if(getaf())
-		noar();
-	while(!getdir()) {
-		if(namc == 0 || match()) {
-			f = creat(file, arbuf.ar_mode & 0777);
-			if(f < 0) {
-				fprintf(stderr, "ar: %s cannot create\n", file);
-				goto sk;
-			}
-			mesg('x');
-			copyfil(af, f, IODD);
-			close(f);
-			continue;
-		}
-	sk:
-		mesg('c');
-		copyfil(af, -1, IODD+SKIP);
-		if (namc > 0  &&  !morefil())
-			done(0);
-	}
+  if (getaf())
+    noar();
+  while (!getdir()) {
+    if (namc == 0 || match()) {
+      f = creat(file, arbuf.ar_mode & 0777);
+      if (f < 0) {
+        fprintf(stderr, "ar: %s cannot create\n", file);
+        goto sk;
+      }
+      mesg('x');
+      copyfil(af, f, IODD);
+      close(f);
+      continue;
+    }
+  sk:
+    mesg('c');
+    copyfil(af, -1, IODD + SKIP);
+    if (namc > 0 && !morefil())
+      done(0);
+  }
 }
 
-pcmd()
-{
+pcmd() {
 
-	if(getaf())
-		noar();
-	while(!getdir()) {
-		if(namc == 0 || match()) {
-			if(flg['v'-'a']) {
-				printf("\n<%s>\n\n", file);
-				fflush(stdout);
-			}
-			copyfil(af, 1, IODD);
-			continue;
-		}
-		copyfil(af, -1, IODD+SKIP);
-	}
+  if (getaf())
+    noar();
+  while (!getdir()) {
+    if (namc == 0 || match()) {
+      if (flg['v' - 'a']) {
+        printf("\n<%s>\n\n", file);
+        fflush(stdout);
+      }
+      copyfil(af, 1, IODD);
+      continue;
+    }
+    copyfil(af, -1, IODD + SKIP);
+  }
 }
 
-mcmd()
-{
+mcmd() {
 
-	init();
-	if(getaf())
-		noar();
-	tf2nam = mktemp(tmp2nam);
-	close(creat(tf2nam, 0600));
-	tf2 = open(tf2nam, 2);
-	if(tf2 < 0) {
-		fprintf(stderr, "ar: cannot create third temp\n");
-		done(1);
-	}
-	while(!getdir()) {
-		bamatch();
-		if(match()) {
-			mesg('m');
-			copyfil(af, tf2, IODD+OODD+HEAD);
-			continue;
-		}
-		mesg('c');
-		copyfil(af, tf, IODD+OODD+HEAD);
-	}
-	install();
+  init();
+  if (getaf())
+    noar();
+  tf2nam = mktemp(tmp2nam);
+  close(creat(tf2nam, 0600));
+  tf2 = open(tf2nam, 2);
+  if (tf2 < 0) {
+    fprintf(stderr, "ar: cannot create third temp\n");
+    done(1);
+  }
+  while (!getdir()) {
+    bamatch();
+    if (match()) {
+      mesg('m');
+      copyfil(af, tf2, IODD + OODD + HEAD);
+      continue;
+    }
+    mesg('c');
+    copyfil(af, tf, IODD + OODD + HEAD);
+  }
+  install();
 }
 
-tcmd()
-{
+tcmd() {
 
-	if(getaf())
-		noar();
-	while(!getdir()) {
-		if(namc == 0 || match()) {
-			if(flg['v'-'a'])
-				longt();
-			printf("%s\n", trim(file));
-		}
-		copyfil(af, -1, IODD+SKIP);
-	}
+  if (getaf())
+    noar();
+  while (!getdir()) {
+    if (namc == 0 || match()) {
+      if (flg['v' - 'a'])
+        longt();
+      printf("%s\n", trim(file));
+    }
+    copyfil(af, -1, IODD + SKIP);
+  }
 }
 
-qcmd()
-{
-	register i, f;
+qcmd() {
+  register i, f;
 
-	if (flg['a'-'a'] || flg['b'-'a']) {
-		fprintf(stderr, "ar: abi not allowed with q\n");
-		done(1);
-	}
-	getqf();
-	for(i=0; signum[i]; i++)
-		signal(signum[i], SIG_IGN);
-	lseek(qf, 0l, 2);
-	for(i=0; i<namc; i++) {
-		file = namv[i];
-		if(file == 0)
-			continue;
-		namv[i] = 0;
-		mesg('q');
-		f = stats();
-		if(f < 0) {
-			fprintf(stderr, "ar: %s cannot open\n", file);
-			continue;
-		}
-		tf = qf;
-		movefil(f);
-		qf = tf;
-	}
+  if (flg['a' - 'a'] || flg['b' - 'a']) {
+    fprintf(stderr, "ar: abi not allowed with q\n");
+    done(1);
+  }
+  getqf();
+  for (i = 0; signum[i]; i++)
+    signal(signum[i], SIG_IGN);
+  lseek(qf, 0l, 2);
+  for (i = 0; i < namc; i++) {
+    file = namv[i];
+    if (file == 0)
+      continue;
+    namv[i] = 0;
+    mesg('q');
+    f = stats();
+    if (f < 0) {
+      fprintf(stderr, "ar: %s cannot open\n", file);
+      continue;
+    }
+    tf = qf;
+    movefil(f);
+    qf = tf;
+  }
 }
 
-init()
-{
-	static mbuf = ARMAG;
+init() {
+  static mbuf = ARMAG;
 
-	tfnam = mktemp(tmp0nam);
-	close(creat(tfnam, 0600));
-	tf = open(tfnam, 2);
-	if(tf < 0) {
-		fprintf(stderr, "ar: cannot create temp file\n");
-		done(1);
-	}
-	if (write(tf, (char *)&mbuf, sizeof(int)) != sizeof(int))
-		wrerr();
+  tfnam = mktemp(tmp0nam);
+  close(creat(tfnam, 0600));
+  tf = open(tfnam, 2);
+  if (tf < 0) {
+    fprintf(stderr, "ar: cannot create temp file\n");
+    done(1);
+  }
+  if (write(tf, (char *)&mbuf, sizeof(int)) != sizeof(int))
+    wrerr();
 }
 
-getaf()
-{
-	int mbuf;
+getaf() {
+  int mbuf;
 
-	af = open(arnam, 0);
-	if(af < 0)
-		return(1);
-	if (read(af, (char *)&mbuf, sizeof(int)) != sizeof(int) || mbuf!=ARMAG) {
-		fprintf(stderr, "ar: %s not in archive format\n", arnam);
-		done(1);
-	}
-	return(0);
+  af = open(arnam, 0);
+  if (af < 0)
+    return (1);
+  if (read(af, (char *)&mbuf, sizeof(int)) != sizeof(int) || mbuf != ARMAG) {
+    fprintf(stderr, "ar: %s not in archive format\n", arnam);
+    done(1);
+  }
+  return (0);
 }
 
-getqf()
-{
-	int mbuf;
+getqf() {
+  int mbuf;
 
-	if ((qf = open(arnam, 2)) < 0) {
-		if(!flg['c'-'a'])
-			fprintf(stderr, "ar: creating %s\n", arnam);
-		close(creat(arnam, 0666));
-		if ((qf = open(arnam, 2)) < 0) {
-			fprintf(stderr, "ar: cannot create %s\n", arnam);
-			done(1);
-		}
-		mbuf = ARMAG;
-		if (write(qf, (char *)&mbuf, sizeof(int)) != sizeof(int))
-			wrerr();
-	}
-	else if (read(qf, (char *)&mbuf, sizeof(int)) != sizeof(int)
-		|| mbuf!=ARMAG) {
-		fprintf(stderr, "ar: %s not in archive format\n", arnam);
-		done(1);
-	}
+  if ((qf = open(arnam, 2)) < 0) {
+    if (!flg['c' - 'a'])
+      fprintf(stderr, "ar: creating %s\n", arnam);
+    close(creat(arnam, 0666));
+    if ((qf = open(arnam, 2)) < 0) {
+      fprintf(stderr, "ar: cannot create %s\n", arnam);
+      done(1);
+    }
+    mbuf = ARMAG;
+    if (write(qf, (char *)&mbuf, sizeof(int)) != sizeof(int))
+      wrerr();
+  } else if (read(qf, (char *)&mbuf, sizeof(int)) != sizeof(int) ||
+             mbuf != ARMAG) {
+    fprintf(stderr, "ar: %s not in archive format\n", arnam);
+    done(1);
+  }
 }
 
-usage()
-{
-	printf("usage: ar [%s][%s] archive files ...\n", opt, man);
-	done(1);
+usage() {
+  printf("usage: ar [%s][%s] archive files ...\n", opt, man);
+  done(1);
 }
 
-noar()
-{
+noar() {
 
-	fprintf(stderr, "ar: %s does not exist\n", arnam);
-	done(1);
+  fprintf(stderr, "ar: %s does not exist\n", arnam);
+  done(1);
 }
 
-sigdone()
-{
-	done(100);
+sigdone() { done(100); }
+
+done(c) {
+
+  if (tfnam)
+    unlink(tfnam);
+  if (tf1nam)
+    unlink(tf1nam);
+  if (tf2nam)
+    unlink(tf2nam);
+  exit(c);
 }
 
-done(c)
-{
+notfound() {
+  register i, n;
 
-	if(tfnam)
-		unlink(tfnam);
-	if(tf1nam)
-		unlink(tf1nam);
-	if(tf2nam)
-		unlink(tf2nam);
-	exit(c);
+  n = 0;
+  for (i = 0; i < namc; i++)
+    if (namv[i]) {
+      fprintf(stderr, "ar: %s not found\n", namv[i]);
+      n++;
+    }
+  return (n);
 }
 
-notfound()
-{
-	register i, n;
+morefil() {
+  register i, n;
 
-	n = 0;
-	for(i=0; i<namc; i++)
-		if(namv[i]) {
-			fprintf(stderr, "ar: %s not found\n", namv[i]);
-			n++;
-		}
-	return(n);
+  n = 0;
+  for (i = 0; i < namc; i++)
+    if (namv[i])
+      n++;
+  return (n);
 }
 
-morefil()
-{
-	register i, n;
+cleanup() {
+  register i, f;
 
-	n = 0;
-	for(i=0; i<namc; i++)
-		if(namv[i])
-			n++;
-	return(n);
+  for (i = 0; i < namc; i++) {
+    file = namv[i];
+    if (file == 0)
+      continue;
+    namv[i] = 0;
+    mesg('a');
+    f = stats();
+    if (f < 0) {
+      fprintf(stderr, "ar: %s cannot open\n", file);
+      continue;
+    }
+    movefil(f);
+  }
+  install();
 }
 
-cleanup()
-{
-	register i, f;
+install() {
+  register i;
 
-	for(i=0; i<namc; i++) {
-		file = namv[i];
-		if(file == 0)
-			continue;
-		namv[i] = 0;
-		mesg('a');
-		f = stats();
-		if(f < 0) {
-			fprintf(stderr, "ar: %s cannot open\n", file);
-			continue;
-		}
-		movefil(f);
-	}
-	install();
-}
-
-install()
-{
-	register i;
-
-	for(i=0; signum[i]; i++)
-		signal(signum[i], SIG_IGN);
-	if(af < 0)
-		if(!flg['c'-'a'])
-			fprintf(stderr, "ar: creating %s\n", arnam);
-	close(af);
-	af = creat(arnam, 0666);
-	if(af < 0) {
-		fprintf(stderr, "ar: cannot create %s\n", arnam);
-		done(1);
-	}
-	if(tfnam) {
-		lseek(tf, 0l, 0);
-		while((i = read(tf, buf, 1024)) > 0)
-			if (write(af, buf, i) != i)
-				wrerr();
-	}
-	if(tf2nam) {
-		lseek(tf2, 0l, 0);
-		while((i = read(tf2, buf, 1024)) > 0)
-			if (write(af, buf, i) != i)
-				wrerr();
-	}
-	if(tf1nam) {
-		lseek(tf1, 0l, 0);
-		while((i = read(tf1, buf, 1024)) > 0)
-			if (write(af, buf, i) != i)
-				wrerr();
-	}
+  for (i = 0; signum[i]; i++)
+    signal(signum[i], SIG_IGN);
+  if (af < 0)
+    if (!flg['c' - 'a'])
+      fprintf(stderr, "ar: creating %s\n", arnam);
+  close(af);
+  af = creat(arnam, 0666);
+  if (af < 0) {
+    fprintf(stderr, "ar: cannot create %s\n", arnam);
+    done(1);
+  }
+  if (tfnam) {
+    lseek(tf, 0l, 0);
+    while ((i = read(tf, buf, 1024)) > 0)
+      if (write(af, buf, i) != i)
+        wrerr();
+  }
+  if (tf2nam) {
+    lseek(tf2, 0l, 0);
+    while ((i = read(tf2, buf, 1024)) > 0)
+      if (write(af, buf, i) != i)
+        wrerr();
+  }
+  if (tf1nam) {
+    lseek(tf1, 0l, 0);
+    while ((i = read(tf1, buf, 1024)) > 0)
+      if (write(af, buf, i) != i)
+        wrerr();
+  }
 }
 
 /*
  * insert the file 'file'
  * into the temporary file
  */
-movefil(f)
-{
-	register char *cp;
-	register i;
+movefil(f) {
+  register char *cp;
+  register i;
 
-	cp = trim(file);
-	for(i=0; i<14; i++)
-		if(arbuf.ar_name[i] = *cp)
-			cp++;
-	arbuf.ar_size = stbuf.st_size;
-	arbuf.ar_date = stbuf.st_mtime;
-	arbuf.ar_uid = stbuf.st_uid;
-	arbuf.ar_gid = stbuf.st_gid;
-	arbuf.ar_mode = stbuf.st_mode;
-	copyfil(f, tf, OODD+HEAD);
-	close(f);
+  cp = trim(file);
+  for (i = 0; i < 14; i++)
+    if (arbuf.ar_name[i] = *cp)
+      cp++;
+  arbuf.ar_size = stbuf.st_size;
+  arbuf.ar_date = stbuf.st_mtime;
+  arbuf.ar_uid = stbuf.st_uid;
+  arbuf.ar_gid = stbuf.st_gid;
+  arbuf.ar_mode = stbuf.st_mode;
+  copyfil(f, tf, OODD + HEAD);
+  close(f);
 }
 
-stats()
-{
-	register f;
+stats() {
+  register f;
 
-	f = open(file, 0);
-	if(f < 0)
-		return(f);
-	if(fstat(f, &stbuf) < 0) {
-		close(f);
-		return(-1);
-	}
-	return(f);
+  f = open(file, 0);
+  if (f < 0)
+    return (f);
+  if (fstat(f, &stbuf) < 0) {
+    close(f);
+    return (-1);
+  }
+  return (f);
 }
 
 /*
  * copy next file
  * size given in arbuf
  */
-copyfil(fi, fo, flag)
-{
-	register i, o;
-	int pe;
+copyfil(fi, fo, flag) {
+  register i, o;
+  int pe;
 
-	if(flag & HEAD)
-		if (write(fo, (char *)&arbuf, sizeof arbuf) != sizeof arbuf)
-			wrerr();
-	pe = 0;
-	while(arbuf.ar_size > 0) {
-		i = o = 1024;
-		if(arbuf.ar_size < i) {
-			i = o = arbuf.ar_size;
-			if(i&1) {
-				if(flag & IODD)
-					i++;
-				if(flag & OODD)
-					o++;
-			}
-		}
-		if(read(fi, buf, i) != i)
-			pe++;
-		if((flag & SKIP) == 0)
-			if (write(fo, buf, o) != o)
-				wrerr();
-		arbuf.ar_size -= 1024;
-	}
-	if(pe)
-		phserr();
+  if (flag & HEAD)
+    if (write(fo, (char *)&arbuf, sizeof arbuf) != sizeof arbuf)
+      wrerr();
+  pe = 0;
+  while (arbuf.ar_size > 0) {
+    i = o = 1024;
+    if (arbuf.ar_size < i) {
+      i = o = arbuf.ar_size;
+      if (i & 1) {
+        if (flag & IODD)
+          i++;
+        if (flag & OODD)
+          o++;
+      }
+    }
+    if (read(fi, buf, i) != i)
+      pe++;
+    if ((flag & SKIP) == 0)
+      if (write(fo, buf, o) != o)
+        wrerr();
+    arbuf.ar_size -= 1024;
+  }
+  if (pe)
+    phserr();
 }
 
-getdir()
-{
-	register i;
+getdir() {
+  register i;
 
-	i = read(af, (char *)&arbuf, sizeof arbuf);
-	if(i != sizeof arbuf) {
-		if(tf1nam) {
-			i = tf;
-			tf = tf1;
-			tf1 = i;
-		}
-		return(1);
-	}
-	for(i=0; i<14; i++)
-		name[i] = arbuf.ar_name[i];
-	file = name;
-	return(0);
+  i = read(af, (char *)&arbuf, sizeof arbuf);
+  if (i != sizeof arbuf) {
+    if (tf1nam) {
+      i = tf;
+      tf = tf1;
+      tf1 = i;
+    }
+    return (1);
+  }
+  for (i = 0; i < 14; i++)
+    name[i] = arbuf.ar_name[i];
+  file = name;
+  return (0);
 }
 
-match()
-{
-	register i;
+match() {
+  register i;
 
-	for(i=0; i<namc; i++) {
-		if(namv[i] == 0)
-			continue;
-		if(strcmp(trim(namv[i]), file) == 0) {
-			file = namv[i];
-			namv[i] = 0;
-			return(1);
-		}
-	}
-	return(0);
+  for (i = 0; i < namc; i++) {
+    if (namv[i] == 0)
+      continue;
+    if (strcmp(trim(namv[i]), file) == 0) {
+      file = namv[i];
+      namv[i] = 0;
+      return (1);
+    }
+  }
+  return (0);
 }
 
-bamatch()
-{
-	register f;
+bamatch() {
+  register f;
 
-	switch(bastate) {
+  switch (bastate) {
 
-	case 1:
-		if(strcmp(file, ponam) != 0)
-			return;
-		bastate = 2;
-		if(flg['a'-'a'])
-			return;
+  case 1:
+    if (strcmp(file, ponam) != 0)
+      return;
+    bastate = 2;
+    if (flg['a' - 'a'])
+      return;
 
-	case 2:
-		bastate = 0;
-		tf1nam = mktemp(tmp1nam);
-		close(creat(tf1nam, 0600));
-		f = open(tf1nam, 2);
-		if(f < 0) {
-			fprintf(stderr, "ar: cannot create second temp\n");
-			return;
-		}
-		tf1 = tf;
-		tf = f;
-	}
+  case 2:
+    bastate = 0;
+    tf1nam = mktemp(tmp1nam);
+    close(creat(tf1nam, 0600));
+    f = open(tf1nam, 2);
+    if (f < 0) {
+      fprintf(stderr, "ar: cannot create second temp\n");
+      return;
+    }
+    tf1 = tf;
+    tf = f;
+  }
 }
 
-phserr()
-{
+phserr() { fprintf(stderr, "ar: phase error on %s\n", file); }
 
-	fprintf(stderr, "ar: phase error on %s\n", file);
+mesg(c) {
+
+  if (flg['v' - 'a'])
+    if (c != 'c' || flg['v' - 'a'] > 1)
+      printf("%c - %s\n", c, file);
 }
 
-mesg(c)
-{
-
-	if(flg['v'-'a'])
-		if(c != 'c' || flg['v'-'a'] > 1)
-			printf("%c - %s\n", c, file);
-}
-
-char *
-trim(s)
+char *trim(s)
 char *s;
 {
-	register char *p1, *p2;
+  register char *p1, *p2;
 
-	for(p1 = s; *p1; p1++)
-		;
-	while(p1 > s) {
-		if(*--p1 != '/')
-			break;
-		*p1 = 0;
-	}
-	p2 = s;
-	for(p1 = s; *p1; p1++)
-		if(*p1 == '/')
-			p2 = p1+1;
-	return(p2);
+  for (p1 = s; *p1; p1++)
+    ;
+  while (p1 > s) {
+    if (*--p1 != '/')
+      break;
+    *p1 = 0;
+  }
+  p2 = s;
+  for (p1 = s; *p1; p1++)
+    if (*p1 == '/')
+      p2 = p1 + 1;
+  return (p2);
 }
 
-#define	IFMT	060000
-#define	ISARG	01000
-#define	LARGE	010000
-#define	SUID	04000
-#define	SGID	02000
-#define	ROWN	0400
-#define	WOWN	0200
-#define	XOWN	0100
-#define	RGRP	040
-#define	WGRP	020
-#define	XGRP	010
-#define	ROTH	04
-#define	WOTH	02
-#define	XOTH	01
-#define	STXT	01000
+#define IFMT 060000
+#define ISARG 01000
+#define LARGE 010000
+#define SUID 04000
+#define SGID 02000
+#define ROWN 0400
+#define WOWN 0200
+#define XOWN 0100
+#define RGRP 040
+#define WGRP 020
+#define XGRP 010
+#define ROTH 04
+#define WOTH 02
+#define XOTH 01
+#define STXT 01000
 
-longt()
-{
-	register char *cp;
+longt() {
+  register char *cp;
 
-	pmode();
-	printf("%3d/%1d", arbuf.ar_uid, arbuf.ar_gid);
-	printf("%7D", arbuf.ar_size);
-	cp = ctime(&arbuf.ar_date);
-	printf(" %-12.12s %-4.4s ", cp+4, cp+20);
+  pmode();
+  printf("%3d/%1d", arbuf.ar_uid, arbuf.ar_gid);
+  printf("%7D", arbuf.ar_size);
+  cp = ctime(&arbuf.ar_date);
+  printf(" %-12.12s %-4.4s ", cp + 4, cp + 20);
 }
 
-int	m1[] = { 1, ROWN, 'r', '-' };
-int	m2[] = { 1, WOWN, 'w', '-' };
-int	m3[] = { 2, SUID, 's', XOWN, 'x', '-' };
-int	m4[] = { 1, RGRP, 'r', '-' };
-int	m5[] = { 1, WGRP, 'w', '-' };
-int	m6[] = { 2, SGID, 's', XGRP, 'x', '-' };
-int	m7[] = { 1, ROTH, 'r', '-' };
-int	m8[] = { 1, WOTH, 'w', '-' };
-int	m9[] = { 2, STXT, 't', XOTH, 'x', '-' };
+int m1[] = {1, ROWN, 'r', '-'};
+int m2[] = {1, WOWN, 'w', '-'};
+int m3[] = {2, SUID, 's', XOWN, 'x', '-'};
+int m4[] = {1, RGRP, 'r', '-'};
+int m5[] = {1, WGRP, 'w', '-'};
+int m6[] = {2, SGID, 's', XGRP, 'x', '-'};
+int m7[] = {1, ROTH, 'r', '-'};
+int m8[] = {1, WOTH, 'w', '-'};
+int m9[] = {2, STXT, 't', XOTH, 'x', '-'};
 
-int	*m[] = { m1, m2, m3, m4, m5, m6, m7, m8, m9};
+int *m[] = {m1, m2, m3, m4, m5, m6, m7, m8, m9};
 
-pmode()
-{
-	register int **mp;
+pmode() {
+  register int **mp;
 
-	for (mp = &m[0]; mp < &m[9];)
-		select(*mp++);
+  for (mp = &m[0]; mp < &m[9];)
+    select(*mp++);
 }
 
-select(pairp)
-int *pairp;
+select(pairp) int *pairp;
 {
-	register int n, *ap;
+  register int n, *ap;
 
-	ap = pairp;
-	n = *ap++;
-	while (--n>=0 && (arbuf.ar_mode&*ap++)==0)
-		ap++;
-	putchar(*ap);
+  ap = pairp;
+  n = *ap++;
+  while (--n >= 0 && (arbuf.ar_mode & *ap++) == 0)
+    ap++;
+  putchar(*ap);
 }
 
-wrerr()
-{
-	perror("ar write error");
-	done(1);
+wrerr() {
+  perror("ar write error");
+  done(1);
 }

--- a/src/cmd/arcv.c
+++ b/src/cmd/arcv.c
@@ -4,103 +4,110 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file arcv.c
+ * @brief Convert old archive format.
+ */
 
 /*
  * Convert old to new archive format
-*/
+ */
 
 static char Sccsid[] = "@(#)arcv.c 3.0 4/21/86";
-#include <signal.h>
 #include <ar.h>
+#include <signal.h>
 
-#define	omag	0177555
+#define omag 0177555
 
-struct	ar_hdr nh;
-struct
-{
-	char	oname[8];
-	long	odate;
-	char	ouid;
-	char	omode;
-	unsigned siz;
+struct ar_hdr nh;
+struct {
+  char oname[8];
+  long odate;
+  char ouid;
+  char omode;
+  unsigned siz;
 } oh;
 
-char	*tmp;
-char	*mktemp();
-int	f;
-int	tf;
+char *tmp;
+char *mktemp();
+int f;
+int tf;
 union {
-	char	buf[1024];
-	int	magic;
+  char buf[1024];
+  int magic;
 } b;
 
-main(argc, argv)
-char *argv[];
-{
-	register i;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  register i;
 
-	tmp = mktemp("/tmp/arcXXXXX");
-	for(i=1; i<4; i++)
-		signal(i, SIG_IGN);
-	for(i=1; i<argc; i++)
-		conv(argv[i]);
-	unlink(tmp);
+  tmp = mktemp("/tmp/arcXXXXX");
+  for (i = 1; i < 4; i++)
+    signal(i, SIG_IGN);
+  for (i = 1; i < argc; i++)
+    conv(argv[i]);
+  unlink(tmp);
 }
 
-conv(fil)
-char *fil;
+conv(fil) char *fil;
 {
-	register unsigned i, n;
+  register unsigned i, n;
 
-	f = open(fil, 2);
-	if(f < 0) {
-		printf("arcv: cannot open %s\n", fil);
-		return;
-	}
-	close(creat(tmp, 0600));
-	tf = open(tmp, 2);
-	if(tf < 0) {
-		printf("arcv: cannot open temp\n");
-		close(f);
-		return;
-	}
-	b.magic = 0;
-	read(f, (char *)&b.magic, sizeof(b.magic));
-	if(b.magic != omag) {
-		printf("arcv: %s not archive format\n", fil);
-		close(tf);
-		close(f);
-		return;
-	}
-	b.magic = ARMAG;
-	write(tf, (char *)&b.magic, sizeof(b.magic));
+  f = open(fil, 2);
+  if (f < 0) {
+    printf("arcv: cannot open %s\n", fil);
+    return;
+  }
+  close(creat(tmp, 0600));
+  tf = open(tmp, 2);
+  if (tf < 0) {
+    printf("arcv: cannot open temp\n");
+    close(f);
+    return;
+  }
+  b.magic = 0;
+  read(f, (char *)&b.magic, sizeof(b.magic));
+  if (b.magic != omag) {
+    printf("arcv: %s not archive format\n", fil);
+    close(tf);
+    close(f);
+    return;
+  }
+  b.magic = ARMAG;
+  write(tf, (char *)&b.magic, sizeof(b.magic));
 loop:
-	i = read(f, (char *)&oh, sizeof(oh));
-	if(i != sizeof(oh))
-		goto out;
-	for(i=0; i<8; i++)
-		nh.ar_name[i] = oh.oname[i];
-	nh.ar_size = oh.siz;
-	nh.ar_uid = oh.ouid;
-	nh.ar_gid = 1;
-	nh.ar_mode = 0666;
-	nh.ar_date = oh.odate;
-	n = (oh.siz+1) & ~01;
-	write(tf, (char *)&nh, sizeof(nh));
-	while(n > 0) {
-		i = 1024;
-		if(n < i)
-			i = n;
-		read(f, b.buf, i);
-		write(tf, b.buf, i);
-		n -= i;
-	}
-	goto loop;
+  i = read(f, (char *)&oh, sizeof(oh));
+  if (i != sizeof(oh))
+    goto out;
+  for (i = 0; i < 8; i++)
+    nh.ar_name[i] = oh.oname[i];
+  nh.ar_size = oh.siz;
+  nh.ar_uid = oh.ouid;
+  nh.ar_gid = 1;
+  nh.ar_mode = 0666;
+  nh.ar_date = oh.odate;
+  n = (oh.siz + 1) & ~01;
+  write(tf, (char *)&nh, sizeof(nh));
+  while (n > 0) {
+    i = 1024;
+    if (n < i)
+      i = n;
+    read(f, b.buf, i);
+    write(tf, b.buf, i);
+    n -= i;
+  }
+  goto loop;
 out:
-	lseek(f, 0L, 0);
-	lseek(tf, 0L, 0);
-	while((i=read(tf, b.buf, 1024)) > 0)
-		write(f, b.buf, i);
-	close(f);
-	close(tf);
+  lseek(f, 0L, 0);
+  lseek(tf, 0L, 0);
+  while ((i = read(tf, b.buf, 1024)) > 0)
+    write(f, b.buf, i);
+  close(f);
+  close(tf);
 }

--- a/src/cmd/at.c
+++ b/src/cmd/at.c
@@ -4,6 +4,10 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file at.c
+ * @brief Schedule commands for later execution.
+ */
 
 /*
  * at time mon day
@@ -12,307 +16,289 @@
  *
  */
 static char Sccsid[] = "@(#)at.c 3.0 4/21/86";
-#include <stdio.h>
 #include <ctype.h>
-#include <time.h>
 #include <signal.h>
+#include <stdio.h>
+#include <time.h>
 
 #define HOUR 100
-#define HALFDAY	(12*HOUR)
-#define DAY	(24*HOUR)
+#define HALFDAY (12 * HOUR)
+#define DAY (24 * HOUR)
 #define THISDAY "/usr/spool/at"
 
 char *days[] = {
-	"sunday",
-	"monday",
-	"tuesday",
-	"wednesday",
-	"thursday",
-	"friday",
-	"saturday",
+    "sunday",   "monday", "tuesday",  "wednesday",
+    "thursday", "friday", "saturday",
 };
 
 struct monstr {
-	char *mname; 
-	int mlen;
+  char *mname;
+  int mlen;
 } months[] = {
-	{ "january", 31 },
-	{ "february", 28 },
-	{ "march", 31 },
-	{ "april", 30 },
-	{ "may", 31 },
-	{ "june", 30 },
-	{ "july", 31 },
-	{ "august", 31 },
-	{ "september", 30 },
-	{ "october", 31 },
-	{ "november", 30 },
-	{ "december", 31 },
-	{ 0, 0 },
+    {"january", 31}, {"february", 28}, {"march", 31},
+    {"april", 30},   {"may", 31},      {"june", 30},
+    {"july", 31},    {"august", 31},   {"september", 30},
+    {"october", 31}, {"november", 30}, {"december", 31},
+    {0, 0},
 };
 
-char	fname[100];
-int	utime;  /* requested time in grains */
-int	now;	/* when is it */
-int	uday; /* day of year to be done */
-int	uyear; /* year */
-int	today; /* day of year today */
-FILE	*file;
-FILE	*ifile;
-char	**environ;
-char	*prefix();
-FILE	*popen();
+char fname[100];
+int utime; /* requested time in grains */
+int now;   /* when is it */
+int uday;  /* day of year to be done */
+int uyear; /* year */
+int today; /* day of year today */
+FILE *file;
+FILE *ifile;
+char **environ;
+char *prefix();
+FILE *popen();
 
-main(argc, argv)
-char **argv;
-{
-	extern onintr();
-	register c;
-	char pwbuf[100];
-	FILE *pwfil;
-	int larg;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  extern onintr();
+  register c;
+  char pwbuf[100];
+  FILE *pwfil;
+  int larg;
 
-	/* argv[1] is the user's time: e.g.,  3AM */
-	/* argv[2] is a month name or day of week */
-	/* argv[3] is day of month or 'week' */
-	/* another argument might be an input file */
-	if (argc < 2) {
-		fprintf(stderr, "at: arg count\n");
-		exit(1);
-	}
-	makeutime(argv[1]);
-	larg = makeuday(argc,argv)+1;
-	if (uday==today && larg<=2 && utime<=now)
-		uday++;
-	c = uyear%4==0? 366: 365;
-	if (uday >= c) {
-		uday -= c;
-		uyear++;
-	}
-	filename(THISDAY, uyear, uday, utime);
-	ifile = stdin;
-	if (argc > larg)
-		ifile = fopen(argv[larg], "r");
-	if (ifile == NULL) {
-		fprintf(stderr, "at: cannot open input: %s\n", argv[larg]);
-		exit(1);
-	}
-	if (signal(SIGINT, SIG_IGN) != SIG_IGN)
-		signal(SIGINT, onintr);
-	file = fopen(fname, "a");
-	chmod(fname, 0644);
-	if (file == NULL) {
-		fprintf(stderr, "at: cannot open memo file\n");
-		exit(1);
-	}
-	if ((pwfil = popen("pwd", "r")) == NULL) {
-		fprintf(stderr, "at: can't execute pwd\n");
-		exit(1);
-	}
-	fgets(pwbuf, 100, pwfil);
-	pclose(pwfil);
-	fprintf(file, "cd %s", pwbuf);
-	if (environ) {
-		char **ep = environ;
-		while(*ep)
-			fprintf(file, "%s\n", *ep++);
-	}
-	while((c = getc(ifile)) != EOF) {
-		putc(c, file);
-	}
-	exit(0);
+  /* argv[1] is the user's time: e.g.,  3AM */
+  /* argv[2] is a month name or day of week */
+  /* argv[3] is day of month or 'week' */
+  /* another argument might be an input file */
+  if (argc < 2) {
+    fprintf(stderr, "at: arg count\n");
+    exit(1);
+  }
+  makeutime(argv[1]);
+  larg = makeuday(argc, argv) + 1;
+  if (uday == today && larg <= 2 && utime <= now)
+    uday++;
+  c = uyear % 4 == 0 ? 366 : 365;
+  if (uday >= c) {
+    uday -= c;
+    uyear++;
+  }
+  filename(THISDAY, uyear, uday, utime);
+  ifile = stdin;
+  if (argc > larg)
+    ifile = fopen(argv[larg], "r");
+  if (ifile == NULL) {
+    fprintf(stderr, "at: cannot open input: %s\n", argv[larg]);
+    exit(1);
+  }
+  if (signal(SIGINT, SIG_IGN) != SIG_IGN)
+    signal(SIGINT, onintr);
+  file = fopen(fname, "a");
+  chmod(fname, 0644);
+  if (file == NULL) {
+    fprintf(stderr, "at: cannot open memo file\n");
+    exit(1);
+  }
+  if ((pwfil = popen("pwd", "r")) == NULL) {
+    fprintf(stderr, "at: can't execute pwd\n");
+    exit(1);
+  }
+  fgets(pwbuf, 100, pwfil);
+  pclose(pwfil);
+  fprintf(file, "cd %s", pwbuf);
+  if (environ) {
+    char **ep = environ;
+    while (*ep)
+      fprintf(file, "%s\n", *ep++);
+  }
+  while ((c = getc(ifile)) != EOF) {
+    putc(c, file);
+  }
+  exit(0);
 }
 
-makeutime(pp)
-char *pp; 
+makeutime(pp) char *pp;
 {
-	register val;
-	register char *p;
+  register val;
+  register char *p;
 
-	/* p points to a user time */
-	p = pp;
-	val = 0;
-	while(isdigit(*p)) {
-		val = val*10+(*p++ -'0');
-	}
-	if (p-pp < 3)
-		val *= HOUR;
+  /* p points to a user time */
+  p = pp;
+  val = 0;
+  while (isdigit(*p)) {
+    val = val * 10 + (*p++ - '0');
+  }
+  if (p - pp < 3)
+    val *= HOUR;
 
-	for (;;) {
-		switch(*p) {
+  for (;;) {
+    switch (*p) {
 
-		case ':':
-			++p;
-			if (isdigit(*p)) {
-				if (isdigit(p[1])) {
-					val +=(10* *p + p[1] - 11*'0');
-					p += 2;
-					continue;
-				}
-			}
-			fprintf(stderr, "at: bad time format:\n");
-			exit(1);
+    case ':':
+      ++p;
+      if (isdigit(*p)) {
+        if (isdigit(p[1])) {
+          val += (10 * *p + p[1] - 11 * '0');
+          p += 2;
+          continue;
+        }
+      }
+      fprintf(stderr, "at: bad time format:\n");
+      exit(1);
 
-		case 'A':
-		case 'a':
-			if (val >= HALFDAY+HOUR)
-				val = DAY+1;  /* illegal */
-			if (val >= HALFDAY && val <(HALFDAY+HOUR))
-				val -= HALFDAY;
-			break;
+    case 'A':
+    case 'a':
+      if (val >= HALFDAY + HOUR)
+        val = DAY + 1; /* illegal */
+      if (val >= HALFDAY && val < (HALFDAY + HOUR))
+        val -= HALFDAY;
+      break;
 
-		case 'P':
-		case 'p':
-			if (val >= HALFDAY+HOUR)
-				val = DAY+1;  /* illegal */
-			if (val < HALFDAY)
-				val += HALFDAY;
-			break;
+    case 'P':
+    case 'p':
+      if (val >= HALFDAY + HOUR)
+        val = DAY + 1; /* illegal */
+      if (val < HALFDAY)
+        val += HALFDAY;
+      break;
 
-		case 'n':
-		case 'N':
-			if ((strncmp(p,"now",3) == 0) ||
-			    (strncmp(p,"NOW",3) == 0)) {
-				fprintf(stderr,"at: don't know about 'now'\n");
-				exit(1);
-			}
-			val = HALFDAY;
-			break;
+    case 'n':
+    case 'N':
+      if ((strncmp(p, "now", 3) == 0) || (strncmp(p, "NOW", 3) == 0)) {
+        fprintf(stderr, "at: don't know about 'now'\n");
+        exit(1);
+      }
+      val = HALFDAY;
+      break;
 
-		case 'M':
-		case 'm':
-			val = 0;
-			break;
+    case 'M':
+    case 'm':
+      val = 0;
+      break;
 
+    case '\0':
+    case ' ':
+      /* 24 hour time */
+      if (val == DAY)
+        val -= DAY;
+      break;
 
-		case '\0':
-		case ' ':
-			/* 24 hour time */
-			if (val == DAY)
-				val -= DAY;
-			break;
-
-		default:
-			fprintf(stderr, "at: bad time format\n");
-			exit(1);
-
-		}
-		break;
-	}
-	if (val < 0 || val >= DAY) {
-		fprintf(stderr, "at: time out of range\n");
-		exit(1);
-	}
-	if (val%HOUR >= 60) {
-		fprintf(stderr, "at: illegal minute field\n");
-		exit(1);
-	}
-	utime = val;
+    default:
+      fprintf(stderr, "at: bad time format\n");
+      exit(1);
+    }
+    break;
+  }
+  if (val < 0 || val >= DAY) {
+    fprintf(stderr, "at: time out of range\n");
+    exit(1);
+  }
+  if (val % HOUR >= 60) {
+    fprintf(stderr, "at: illegal minute field\n");
+    exit(1);
+  }
+  utime = val;
 }
 
+makeuday(argc, argv) {
+  /* the presumption is that argv[2], argv[3] are either
+     month day OR weekday [week].  Returns either 2 or 3 as last
+     argument used */
+  /* first of all, what's today */
+  long tm;
+  int found = -1;
+  char **ps;
+  struct tm *detail, *localtime();
+  struct monstr *pt;
 
-makeuday(argc,argv)
-char **argv;
-{
-	/* the presumption is that argv[2], argv[3] are either
-	   month day OR weekday [week].  Returns either 2 or 3 as last
-	   argument used */
-	/* first of all, what's today */
-	long tm;
-	int found = -1;
-	char **ps;
-	struct tm *detail, *localtime();
-	struct monstr *pt;
-
-	time(&tm);
-	detail = localtime(&tm);
-	uday = today = detail->tm_yday;
-	uyear = detail->tm_year;
-	now = detail->tm_hour*100+detail->tm_min;
-	if (argc<=2)
-		return(1);
-	/* is the next argument a month name ? */
-	for (pt=months; pt->mname; pt++) {
-		if (prefix(argv[2], pt->mname)) {
-			if (found<0)
-				found = pt-months;
-			else {
-				fprintf(stderr, "at: ambiguous month\n");
-				exit(1);
-			}
-		}
-	}
-	if (found>=0) {
-		if (argc<=3)
-			return(2);
-		uday = atoi(argv[3]) - 1;
-		if (uday<0) {
-			fprintf(stderr, "at: illegal day\n");
-			exit(1);
-		}
-		while(--found>=0)
-			uday += months[found].mlen;
-		if (detail->tm_year%4==0 && uday>59)
-			uday += 1;
-		return(3);
-	}
-	/* not a month, try day of week */
-	found = -1;
-	for (ps=days; ps<days+7; ps++) {
-		if (prefix(argv[2], *ps)) {
-			if (found<0)
-				found = ps-days;
-			else {
-				fprintf(stderr, "at: ambiguous day of week\n");
-				exit(1);
-			}
-		}
-	}
-	if (found<0)
-		return(1);
-	/* find next day of this sort */
-	uday = found - detail->tm_wday;
-	if (uday<=0)
-		uday += 7;
-	uday += today;
-	if (argc>3 && strcmp("week", argv[3])==0) {
-		uday += 7;
-		return(3);
-	}
-	return(2);
+  time(&tm);
+  detail = localtime(&tm);
+  uday = today = detail->tm_yday;
+  uyear = detail->tm_year;
+  now = detail->tm_hour * 100 + detail->tm_min;
+  if (argc <= 2)
+    return (1);
+  /* is the next argument a month name ? */
+  for (pt = months; pt->mname; pt++) {
+    if (prefix(argv[2], pt->mname)) {
+      if (found < 0)
+        found = pt - months;
+      else {
+        fprintf(stderr, "at: ambiguous month\n");
+        exit(1);
+      }
+    }
+  }
+  if (found >= 0) {
+    if (argc <= 3)
+      return (2);
+    uday = atoi(argv[3]) - 1;
+    if (uday < 0) {
+      fprintf(stderr, "at: illegal day\n");
+      exit(1);
+    }
+    while (--found >= 0)
+      uday += months[found].mlen;
+    if (detail->tm_year % 4 == 0 && uday > 59)
+      uday += 1;
+    return (3);
+  }
+  /* not a month, try day of week */
+  found = -1;
+  for (ps = days; ps < days + 7; ps++) {
+    if (prefix(argv[2], *ps)) {
+      if (found < 0)
+        found = ps - days;
+      else {
+        fprintf(stderr, "at: ambiguous day of week\n");
+        exit(1);
+      }
+    }
+  }
+  if (found < 0)
+    return (1);
+  /* find next day of this sort */
+  uday = found - detail->tm_wday;
+  if (uday <= 0)
+    uday += 7;
+  uday += today;
+  if (argc > 3 && strcmp("week", argv[3]) == 0) {
+    uday += 7;
+    return (3);
+  }
+  return (2);
 }
 
-char *
-prefix(begin, full)
+char *prefix(begin, full)
 char *begin, *full;
 {
-	int c;
-	while (c = *begin++) {
-		if (isupper(c))
-			c = tolower(c);
-		if (*full != c)
-			return(0);
-		else
-			full++;
-	}
-	return(full);
+  int c;
+  while (c = *begin++) {
+    if (isupper(c))
+      c = tolower(c);
+    if (*full != c)
+      return (0);
+    else
+      full++;
+  }
+  return (full);
 }
 
-filename(dir, y, d, t)
-char *dir;
+filename(dir, y, d, t) char *dir;
 {
-	register i;
+  register i;
 
-	for (i=0; ; i += 53) {
-		sprintf(fname, "%s/%02d.%03d.%04d.%02d", dir, y, d, t,
-		   (getpid()+i)%100);
-		if (access(fname, 0) == -1)
-			return;
-	}
+  for (i = 0;; i += 53) {
+    sprintf(fname, "%s/%02d.%03d.%04d.%02d", dir, y, d, t,
+            (getpid() + i) % 100);
+    if (access(fname, 0) == -1)
+      return;
+  }
 }
 
-onintr()
-{
-	unlink(fname);
-	exit(1);
+onintr() {
+  unlink(fname);
+  exit(1);
 }

--- a/src/cmd/atrun.c
+++ b/src/cmd/atrun.c
@@ -4,113 +4,119 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file atrun.c
+ * @brief Run jobs scheduled by at.
+ */
 
 /*
  * Run programs submitted by at.
  */
 static char Sccsid[] = "@(#)atrun.c 3.0 4/21/86";
 #include <stdio.h>
-#include <sys/types.h>
 #include <sys/dir.h>
-#include <time.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
 
-# define DIR "/usr/spool/at"
-# define PDIR	"past"
-# define LASTF "/usr/spool/at/lasttimedone"
+#define DIR "/usr/spool/at"
+#define PDIR "past"
+#define LASTF "/usr/spool/at/lasttimedone"
 
-int	nowtime;
-int	nowdate;
-int	nowyear;
+int nowtime;
+int nowdate;
+int nowyear;
 
-main(argc, argv)
-char **argv;
-{
-	int tt, day, year, uniq;
-	struct direct dirent;
-	char file[DIRSIZ+1];
-	FILE *dirf;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  int tt, day, year, uniq;
+  struct direct dirent;
+  char file[DIRSIZ + 1];
+  FILE *dirf;
 
-	chdir(DIR);
-	makenowtime();
-	if ((dirf = fopen(".", "r")) == NULL) {
-		fprintf(stderr, "Cannot read at directory\n");
-		exit(1);
-	}
-	while (fread((char *)&dirent, sizeof(dirent), 1, dirf) == 1) {
-		if (dirent.d_ino==0)
-			continue;
-		strncpy(file, dirent.d_name, DIRSIZ);
-		file[DIRSIZ] = '\0';
-		if (sscanf(file, "%2d.%3d.%4d.%2d", &year, &day, &tt, &uniq) != 4)
-			continue;
-		if (nowyear < year)
-			continue;
-		if (nowyear==year && nowdate < day)
-			continue;
-		if (nowyear==year && nowdate==day && nowtime < tt)
-			continue;
-		run(file);
-	}
-	fclose(dirf);
-	updatetime(nowtime);
-	exit(0);
+  chdir(DIR);
+  makenowtime();
+  if ((dirf = fopen(".", "r")) == NULL) {
+    fprintf(stderr, "Cannot read at directory\n");
+    exit(1);
+  }
+  while (fread((char *)&dirent, sizeof(dirent), 1, dirf) == 1) {
+    if (dirent.d_ino == 0)
+      continue;
+    strncpy(file, dirent.d_name, DIRSIZ);
+    file[DIRSIZ] = '\0';
+    if (sscanf(file, "%2d.%3d.%4d.%2d", &year, &day, &tt, &uniq) != 4)
+      continue;
+    if (nowyear < year)
+      continue;
+    if (nowyear == year && nowdate < day)
+      continue;
+    if (nowyear == year && nowdate == day && nowtime < tt)
+      continue;
+    run(file);
+  }
+  fclose(dirf);
+  updatetime(nowtime);
+  exit(0);
 }
 
-makenowtime()
-{
-	long t;
-	struct tm *localtime();
-	register struct tm *tp;
+makenowtime() {
+  long t;
+  struct tm *localtime();
+  register struct tm *tp;
 
-	time(&t);
-	tp = localtime(&t);
-	nowtime = tp->tm_hour*100 + tp->tm_min;
-	nowdate = tp->tm_yday;
-	nowyear = tp->tm_year;
+  time(&t);
+  tp = localtime(&t);
+  nowtime = tp->tm_hour * 100 + tp->tm_min;
+  nowdate = tp->tm_yday;
+  nowyear = tp->tm_year;
 }
 
-updatetime(t)
-{
-	FILE *tfile;
+updatetime(t) {
+  FILE *tfile;
 
-	tfile = fopen(LASTF, "w");
-	if (tfile == NULL) {
-		fprintf(stderr, "can't write lastfile\n");
-		exit(1);
-	}
-	fprintf(tfile, "%04d\n", t);
+  tfile = fopen(LASTF, "w");
+  if (tfile == NULL) {
+    fprintf(stderr, "can't write lastfile\n");
+    exit(1);
+  }
+  fprintf(tfile, "%04d\n", t);
 }
 
-run(file)
-char *file;
+run(file) char *file;
 {
-	struct stat stbuf;
-	register pid, i;
-	char sbuf[64];
+  struct stat stbuf;
+  register pid, i;
+  char sbuf[64];
 
-	if (fork()!=0)
-		return;
-	for (i=0; i<15; i++)
-		close(i);
-	dup(dup(open("/dev/null", 0)));
-	sprintf(sbuf, "/bin/mv %.14s %s", file, PDIR);
-	system(sbuf);
-	chdir(PDIR);
-	if (stat(file, &stbuf) == -1)
-		exit(1);
-	setgid(stbuf.st_gid);
-	setuid(stbuf.st_uid);
-	if (pid = fork()) {
-		if (pid == -1)
-			exit(1);
-		wait((int *)0);
-		unlink(file);
-		exit(0);
-	}
-	nice(3);
-	execl("/bin/sh", "sh", file, 0);
-	execl("/usr/bin/sh", "sh", file, 0);
-	fprintf(stderr, "Can't execl shell\n");
-	exit(1);
+  if (fork() != 0)
+    return;
+  for (i = 0; i < 15; i++)
+    close(i);
+  dup(dup(open("/dev/null", 0)));
+  sprintf(sbuf, "/bin/mv %.14s %s", file, PDIR);
+  system(sbuf);
+  chdir(PDIR);
+  if (stat(file, &stbuf) == -1)
+    exit(1);
+  setgid(stbuf.st_gid);
+  setuid(stbuf.st_uid);
+  if (pid = fork()) {
+    if (pid == -1)
+      exit(1);
+    wait((int *)0);
+    unlink(file);
+    exit(0);
+  }
+  nice(3);
+  execl("/bin/sh", "sh", file, 0);
+  execl("/usr/bin/sh", "sh", file, 0);
+  fprintf(stderr, "Can't execl shell\n");
+  exit(1);
 }

--- a/src/cmd/badstat.c
+++ b/src/cmd/badstat.c
@@ -4,6 +4,10 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file badstat.c
+ * @brief Report bad block statistics.
+ */
 
 /*
  * ULTRIX-11 Online Bad Sector status program
@@ -16,15 +20,15 @@
 static char Sccsid[] = "@(#)badstat.c 3.0 4/21/86";
 #define DKBAD
 
-#include <sys/param.h>
-#include <time.h>
-#include <sys/timeb.h>
 #include <a.out.h>
 #include <stdio.h>
-#include <sys/hp_info.h>
 #include <sys/bads.h>
 #include <sys/hkbad.h>
+#include <sys/hp_info.h>
 #include <sys/hpbad.h>
+#include <sys/param.h>
+#include <sys/timeb.h>
+#include <time.h>
 
 /*
  *	BAD144 info for disk bad blocking. A zero entry in
@@ -32,520 +36,486 @@ static char Sccsid[] = "@(#)badstat.c 3.0 4/21/86";
  *	Borrowed from stand-alone DSKINIT, not all info used here.
  */
 
-#define	NP	-1
-#define	HP	1
-#define	HM	2
-#define	HJ	3
+#define NP -1
+#define HP 1
+#define HM 2
+#define HJ 3
 
 struct dkinfo {
-	char	*di_type;	/* type name of disk */
-	int	di_flag;	/* prtdsk() flags */
-	char	*di_name;	/* ULTRIX-11 disk name */
-	long	di_size;	/* size of entire volume in blocks */
-	int	di_nsect;	/* sectors per track */
-	int	di_ntrak;	/* tracks per cylinder */
-	int	di_wcpat[2];	/* worst case pattern */
+  char *di_type;   /* type name of disk */
+  int di_flag;     /* prtdsk() flags */
+  char *di_name;   /* ULTRIX-11 disk name */
+  long di_size;    /* size of entire volume in blocks */
+  int di_nsect;    /* sectors per track */
+  int di_ntrak;    /* tracks per cylinder */
+  int di_wcpat[2]; /* worst case pattern */
 } dkinfo[] = {
-	"rk06",	0,	"hk",	22L*3L*411L,	22, 3, 0135143, 072307,
-	"rk07",	0,	"hk",	22L*3L*815L,	22, 3, 0135143, 072307,
-	"rm02",	NP,	"hp",	32L*5L*823L,	32, 5, 0165555, 0133333,
-	"rm02_0", HP,	"hp",	32L*5L*823L,	32, 5, 0165555, 0133333,
-	"rm02_1", HM,	"hm",	32L*5L*823L,	32, 5, 0165555, 0133333,
-	"rm02_2", HJ,	"hj",	32L*5L*823L,	32, 5, 0165555, 0133333,
-	"rm03",	NP,	"hp",	32L*5L*823L,	32, 5, 0165555, 0133333,
-	"rm03_0", HP,	"hp",	32L*5L*823L,	32, 5, 0165555, 0133333,
-	"rm03_1", HM,	"hm",	32L*5L*823L,	32, 5, 0165555, 0133333,
-	"rm03_2", HJ,	"hj",	32L*5L*823L,	32, 5, 0165555, 0133333,
-	"rm05",	NP,	"hp",	32L*19L*823L,	32, 19, 0165555, 0133333,
-	"rm05_0", HP,	"hp",	32L*19L*823L,	32, 19, 0165555, 0133333,
-	"rm05_1", HM,	"hm",	32L*19L*823L,	32, 19, 0165555, 0133333,
-	"rm05_2", HJ,	"hj",	32L*19L*823L,	32, 19, 0165555, 0133333,
-	"rp04",	NP,	"hp",	22L*19L*411L,	22, 19, 0165555, 0133333,
-	"rp04_0", HP,	"hp",	22L*19L*411L,	22, 19, 0165555, 0133333,
-	"rp04_1", HM,	"hm",	22L*19L*411L,	22, 19, 0165555, 0133333,
-	"rm04_2", HJ,	"hj",	22L*19L*411L,	22, 19, 0165555, 0133333,
-	"rp05",	NP,	"hp",	22L*19L*411L,	22, 19, 0165555, 0133333,
-	"rp05_0", HP,	"hp",	22L*19L*411L,	22, 19, 0165555, 0133333,
-	"rp05_1", HM,	"hm",	22L*19L*411L,	22, 19, 0165555, 0133333,
-	"rp05_2", HJ,	"hj",	22L*19L*411L,	22, 19, 0165555, 0133333,
-	"rp06",	NP,	"hp",	22L*19L*815L,	22, 19, 0165555, 0133333,
-	"rp06_0", HP,	"hp",	22L*19L*815L,	22, 19, 0165555, 0133333,
-	"rp06_1", HM,	"hm",	22L*19L*815L,	22, 19, 0165555, 0133333,
-	"rp06_2", HJ,	"hj",	22L*19L*815L,	22, 19, 0165555, 0133333,
-	0,
+    "rk06",   0,  "hk", 22L * 3L * 411L,  22, 3,  0135143, 072307,
+    "rk07",   0,  "hk", 22L * 3L * 815L,  22, 3,  0135143, 072307,
+    "rm02",   NP, "hp", 32L * 5L * 823L,  32, 5,  0165555, 0133333,
+    "rm02_0", HP, "hp", 32L * 5L * 823L,  32, 5,  0165555, 0133333,
+    "rm02_1", HM, "hm", 32L * 5L * 823L,  32, 5,  0165555, 0133333,
+    "rm02_2", HJ, "hj", 32L * 5L * 823L,  32, 5,  0165555, 0133333,
+    "rm03",   NP, "hp", 32L * 5L * 823L,  32, 5,  0165555, 0133333,
+    "rm03_0", HP, "hp", 32L * 5L * 823L,  32, 5,  0165555, 0133333,
+    "rm03_1", HM, "hm", 32L * 5L * 823L,  32, 5,  0165555, 0133333,
+    "rm03_2", HJ, "hj", 32L * 5L * 823L,  32, 5,  0165555, 0133333,
+    "rm05",   NP, "hp", 32L * 19L * 823L, 32, 19, 0165555, 0133333,
+    "rm05_0", HP, "hp", 32L * 19L * 823L, 32, 19, 0165555, 0133333,
+    "rm05_1", HM, "hm", 32L * 19L * 823L, 32, 19, 0165555, 0133333,
+    "rm05_2", HJ, "hj", 32L * 19L * 823L, 32, 19, 0165555, 0133333,
+    "rp04",   NP, "hp", 22L * 19L * 411L, 22, 19, 0165555, 0133333,
+    "rp04_0", HP, "hp", 22L * 19L * 411L, 22, 19, 0165555, 0133333,
+    "rp04_1", HM, "hm", 22L * 19L * 411L, 22, 19, 0165555, 0133333,
+    "rm04_2", HJ, "hj", 22L * 19L * 411L, 22, 19, 0165555, 0133333,
+    "rp05",   NP, "hp", 22L * 19L * 411L, 22, 19, 0165555, 0133333,
+    "rp05_0", HP, "hp", 22L * 19L * 411L, 22, 19, 0165555, 0133333,
+    "rp05_1", HM, "hm", 22L * 19L * 411L, 22, 19, 0165555, 0133333,
+    "rp05_2", HJ, "hj", 22L * 19L * 411L, 22, 19, 0165555, 0133333,
+    "rp06",   NP, "hp", 22L * 19L * 815L, 22, 19, 0165555, 0133333,
+    "rp06_0", HP, "hp", 22L * 19L * 815L, 22, 19, 0165555, 0133333,
+    "rp06_1", HM, "hm", 22L * 19L * 815L, 22, 19, 0165555, 0133333,
+    "rp06_2", HJ, "hj", 22L * 19L * 815L, 22, 19, 0165555, 0133333,
+    0,
 };
 
-struct nlist nli[] =
-{
-	{ "_nhk" },
-	{ "_nhp" },
-	{ "_hp_inde" },
-	{ "_hk_bads" },
-	{ "_hp_bads" },
-	{ "_hk_dt" },
-	{ "_hp_dt" },
-	{ "" },
+struct nlist nli[] = {
+    {"_nhk"},     {"_nhp"},   {"_hp_inde"}, {"_hk_bads"},
+    {"_hp_bads"}, {"_hk_dt"}, {"_hp_dt"},   {""},
 };
 
-char	*bdhdr[3] = {
-"Bad			   Replace		     Revector",
-"Block #   Cyl  Trk  Sec    Block #   Cyl  Trk  Sec   Count",
-"----------------------------------------------------------"
-};
-
-
+char *bdhdr[3] = {"Bad			   Replace		     Revector",
+                  "Block #   Cyl  Trk  Sec    Block #   Cyl  Trk  Sec   Count",
+                  "----------------------------------------------------------"};
 
 struct dkinfo *dip;
 struct bt_bad *bt;
-long	bn, rbn, atob(), atol();
+long bn, rbn, atob(), atol();
 union {
-	long	serl;		/* pack serial number as a long */
-	int	seri[2];	/* serial number as two int's */
-}dsk;
+  long serl;   /* pack serial number as a long */
+  int seri[2]; /* serial number as two int's */
+} dsk;
 
 struct {
-	int t_cn;
-	int t_tn;
-	int t_sn;
-}da;
-char *usage="badstat: usage  badstat [ifn] [interval] [corefile] [namelist]\n";
+  int t_cn;
+  int t_tn;
+  int t_sn;
+} da;
+char *usage =
+    "badstat: usage  badstat [ifn] [interval] [corefile] [namelist]\n";
 char *coref = "/dev/mem";
 char *infile = "/unix";
 
-char	hp_index[MAXRH];	/* where to find info in HP structures */
-char	hpn[MAXRH];		/* number units per RH controller */
+char hp_index[MAXRH]; /* where to find info in HP structures */
+char hpn[MAXRH];      /* number units per RH controller */
 int nhk, nhp, nhm, nhj, mem, interval, fd;
 struct hkbad *hk_bads[8];
-int	hk_dt[8];
+int hk_dt[8];
 struct hpbad *hp_bads[8];
-char	hp_dt[8];
+char hp_dt[8];
 struct hpbad *hm_bads[8];
-char	hm_dt[8];
+char hm_dt[8];
 struct hpbad *hj_bads[8];
-char	hj_dt[8];
-struct dtype{
-	int	dtyp;
-	char	*dname;
-}d_typ[]  = {
-	0,	"rk06",
-	02000,	"rk07",
-	RP04,	"rp04",
-	RP05,	"rp05",
-	RP06,	"rp06",
-	RM03,	"rm03",
-	RM02,	"rm02",
-	RM05,	"rm05",
-	-1,	"",
+char hj_dt[8];
+struct dtype {
+  int dtyp;
+  char *dname;
+} d_typ[] = {
+    0,      "rk06", 02000,  "rk07", RP04,   "rp04", RP05,   "rp05", RP06,
+    "rp06", RM03,   "rm03", RM02,   "rm02", RM05,   "rm05", -1,     "",
 };
 
-char	dev[30];
-char	hk_av, hp_av, hm_av, hj_av;
+char dev[30];
+char hk_av, hp_av, hm_av, hj_av;
 
 long timbuf;
 char *ap, *timezone(), *ctime(), *asctime();
 struct tm *localtime();
 extern char *ctime();
 
-
-	struct dkbad *bp;
-	struct bt_bad *bt;
-	int cnt, bcnt;
-
-
-main(argc, argp)
-int argc;
-char *argp[];
-{
-	int cnt, cnt1;
-	char *ap;
-
-	argp++;
-	for(ap = *argp++; ap && *ap; ap++)
-		switch(*ap){
-			case 'f':
-				coref = *argp++;
-				break;
-			case 'i':
-				interval = atoi(*argp++);
-				break;
-			case 'n':
-				infile = *argp++;
-				break;
-			case '-':
-				break;
-			default:
-				fprintf(stderr, "%s", usage);
-				exit(1);
-				break;
-		}
-	initmem();
-	while(1){
-		lmem();
-		display();
-		if(interval)
-			sleep(interval);
-		else
-			exit(0);
-	}
-}
-
-initmem()
-{
-	int cnt, cnt1;
-
-	nlist(infile, nli);
-	if((mem = open(coref, 0)) <= 0){
-		printf("badstat: FATAL : Could not open %s\n", coref);
-		exit(1);
-	}
-	if(nli[0].n_value){	/* Check for nhk */
-		lseek(mem, (long)nli[0].n_value, 0);
-		read(mem, &nhk, sizeof(nhk));
-	}
-	if((nli[2].n_value) && (nli[1].n_value)){	/* Check for nhp */
-		lseek(mem, (long)nli[2].n_value, 0);
-		read(mem, &hp_index, MAXRH);
-		lseek(mem, (long)nli[1].n_value, 0);
-		read(mem, &hpn, MAXRH);
-		nhp = hpn[0]; nhm = hpn[1]; nhj = hpn[2];
-	}
-	if(nhk == 0 && nhp == 0 && nhm == 0 && nhj == 0){
-		printf("badstat: W : No bad sector devices on system\n");
-		exit(0);
-	}
-	if(nhk){
-		if(nli[3].n_value == 0)
-			nhk = 0;
-		else{
-
-			for(cnt = 0; cnt < nhk; cnt++){
-				for(cnt1 = 0; cnt1 < 8;cnt1++){
-				  sprintf(dev, "/dev/hk%d%d", cnt,cnt1);
-				  fd = open(dev, 0);
-				  if(fd > 0){
-					if(read(fd, &dev, 1) == 1)
-						hk_av |= (1<<cnt);
-					close(fd);
-					break;
-				  }
-				}
-			}
-			for(cnt = 0; cnt < nhk; cnt++){
-				if((hk_bads[cnt] = malloc(sizeof(struct dkbad)))
-				    <= 0){
-					printf("badstat: F : malloc failed");
-					printf(" for hk %d\n", cnt);
-					exit(1);
-				}
-			}
-			lseek(mem, (long)nli[5].n_value, 0);
-			for(cnt = 0; cnt < nhk; cnt++)
-				read(mem, &hk_dt[cnt], sizeof(int));
-		}
-	}
-	if(nhp){
-		if(nli[4].n_value == 0)
-			nhp = 0;
-		else{
-
-			for(cnt = 0; cnt < nhp; cnt++){
-				for(cnt1 = 0; cnt1 < 8;cnt1++){
-				  sprintf(dev, "/dev/hp%d%d", cnt,cnt1);
-				  fd = open(dev, 0);
-				  if(fd > 0){
-					if(read(fd, &dev, 1) == 1)
-						hp_av |= (1<<cnt);
-					close(fd);
-					break;
-				  }
-				}
-			}
-
-			for(cnt = 0; cnt < nhp; cnt++){
-				if((hp_bads[cnt] = malloc(sizeof(struct dkbad)))
-				    <= 0){
-					printf("badstat: F : malloc failed");
-					printf(" for hp %d\n", cnt);
-					exit(1);
-				}
-			}
-			lseek(mem, (long)nli[6].n_value + hp_index[0], 0);
-			for(cnt = 0; cnt < nhp; cnt++)
-				read(mem, &hp_dt[cnt], sizeof(char));
-		}
-	}
-	if(nhm){
-		if(nli[4].n_value == 0)
-			nhm = 0;
-		else{
-
-			for(cnt = 0; cnt < nhm; cnt++){
-				for(cnt1 = 0; cnt1 < 8;cnt1++){
-				  sprintf(dev, "/dev/hm%d%d", cnt,cnt1);
-				  fd = open(dev, 0);
-				  if(fd > 0){
-					if(read(fd, &dev, 1) == 1)
-						hm_av |= (1<<cnt);
-					close(fd);
-					break;
-				  }
-				}
-			}
-
-			for(cnt = 0; cnt < nhm; cnt++){
-				if((hm_bads[cnt] = malloc(sizeof(struct dkbad)))
-				    <= 0){
-					printf("badstat: F : malloc failed");
-					printf(" for hm %d\n", cnt);
-					exit(1);
-				}
-			}
-			lseek(mem, (long)nli[6].n_value + hp_index[1], 0);
-			for(cnt = 0; cnt < nhm; cnt++)
-				read(mem, &hm_dt[cnt], sizeof(char));
-		}
-	}
-	if(nhj){
-		if(nli[4].n_value == 0)
-			nhj = 0;
-		else{
-
-			for(cnt = 0; cnt < nhj; cnt++){
-				for(cnt1 = 0; cnt1 < 8;cnt1++){
-				  sprintf(dev, "/dev/hj%d%d", cnt,cnt1);
-				  fd = open(dev, 0);
-				  if(fd > 0){
-					if(read(fd, &dev, 1) == 1)
-						hj_av |= (1<<cnt);
-					close(fd);
-					break;
-				  }
-				}
-			}
-
-			for(cnt = 0; cnt < nhj; cnt++){
-				if((hj_bads[cnt] = malloc(sizeof(struct dkbad)))
-				    <= 0){
-					printf("badstat: F : malloc failed");
-					printf(" for hj %d\n", cnt);
-					exit(1);
-				}
-			}
-			lseek(mem, (long)nli[6].n_value + hp_index[2], 0);
-			for(cnt = 0; cnt < nhj; cnt++)
-				read(mem, &hj_dt[cnt], sizeof(char));
-		}
-	}
-	if(hk_av == 0 && hp_av == 0 && hm_av == 0 && hj_av == 0){
-		printf("badstat: F : No bad block info found\n");
-		exit(0);
-	}
-}
-
-lmem()
-{
-	int cnt, i;
-
-	if(nhk){
-		lseek(mem, (long)nli[3].n_value, 0);
-		for(cnt = 0; cnt < nhk; cnt++){
-			read(mem, hk_bads[cnt], sizeof(struct hkbad));
-		}
-	}
-	if(nhp){
-		i = hp_index[0] * sizeof(struct hpbad);
-		lseek(mem, (long)nli[4].n_value + i, 0);
-		for(cnt = 0; cnt < nhp; cnt++){
-			read(mem, hp_bads[cnt], sizeof(struct hpbad));
-		}
-	}
-	if(nhm){
-		i = hp_index[1] * sizeof(struct hpbad);
-		lseek(mem, (long)nli[4].n_value + i, 0);
-		for(cnt = 0; cnt < nhm; cnt++){
-			read(mem, hm_bads[cnt], sizeof(struct hpbad));
-		}
-	}
-	if(nhj){
-		i = hp_index[2] * sizeof(struct hpbad);
-		lseek(mem, (long)nli[4].n_value + i, 0);
-		for(cnt = 0; cnt < nhj; cnt++){
-			read(mem, hj_bads[cnt], sizeof(struct hpbad));
-		}
-	}
-}
-
-display()
-{
-
-	printf("\n\tBad Block Status on ");
-	date();
-	printf("\n");
-	if(hk_av){
-		for(cnt = 0; cnt < nhk; cnt++){
-			if(hk_av & (1<<cnt)){
-				bp = hk_bads[cnt];
-				bt = &bp->bt_badb;
-				if((dip = drvtyp(hk_dt[cnt])) == 0)
-					continue;
-				prtdev(-1, cnt);
-			}
-		}
-	}
-	if(hp_av){
-		for(cnt = 0; cnt < nhp; cnt++){
-			if(hp_av & (1<<cnt)){
-				bp = hp_bads[cnt];
-				bt = &bp->bt_badb;
-				if((dip = drvtyp(hp_dt[cnt])) == 0)
-					continue;
-				prtdev(0, cnt);
-			}
-		}
-	}
-	if(hm_av){
-		for(cnt = 0; cnt < nhm; cnt++){
-			if(hm_av & (1<<cnt)){
-				bp = hm_bads[cnt];
-				bt = &bp->bt_badb;
-				if((dip = drvtyp(hm_dt[cnt])) == 0)
-					continue;
-				prtdev(1, cnt);
-			}
-		}
-	}
-	if(hj_av){
-		for(cnt = 0; cnt < nhj; cnt++){
-			if(hj_av & (1<<cnt)){
-				bp = hj_bads[cnt];
-				bt = &bp->bt_badb;
-				if((dip = drvtyp(hj_dt[cnt])) == 0)
-					continue;
-				prtdev(2, cnt);
-			}
-		}
-	}
-}
-
-prtdev(ctrl, unit)
-{
-	int cnt;
-
-	if(ctrl >= 0)
-		printf("RH %d ", ctrl);
-	printf("%s Unit %d",dip->di_type, unit);
-	if((bp->bt_csnh+bp->bt_csnl) == 0
-	  || bp->bt_flag != 0
-	  || bp->bt_mbz){
-		printf("  NO VALID BAD SECTOR ");
-		printf("INFORMATION\n\n");
-		return;
-	}
-	dsk.seri[0] = bp->bt_csnh;
-	dsk.seri[1] = bp->bt_csnl;
-	printf("  Cartridge Serial #%D  Pack has ", dsk.serl);
-	for(cnt=0, bt= &bp->bt_badb; cnt < dip->di_nsect ;cnt++, bt++){
-		if(bt->bt_cyl==-1&&bt->bt_trksec==-1)
-			break;
-		if(bt->bt_cyl==0&&bt->bt_trksec==0)
-			break;
-	}
-	if(cnt == 0){
-		printf("NO bad sectors\n\n");
-		return;
-	}
-	printf("%d bad sectors\n\n", cnt);
-	bt = &bp->bt_badb;
-	printf("%s\n%s\n%s\n",bdhdr[0], bdhdr[1]
-		, bdhdr[2]);
-	prtsec(bp, bt,  setvec());
-	printf("%s\n\n",bdhdr[2]);
-}
-
-prtsec(bp, bt, vec)
 struct dkbad *bp;
 struct bt_bad *bt;
-int	*vec;
-{
-	int cnt;
+int cnt, bcnt;
 
-	for(cnt=0; cnt < dip->di_nsect ;cnt++, bt++){
-		if(bt->bt_cyl==-1&&bt->bt_trksec==-1)
-			break;
-		if(bt->bt_cyl==0&&bt->bt_trksec==0)
-			break;
-		bn = atob(bt);
-		printf("%7D  %4d  %3d",bn, bt->bt_cyl,bt->bt_trksec>>8);
-		printf("  %3d",bt->bt_trksec&0377);
-		btoa((rbn-1)-cnt);
-		printf("    %7D",(rbn-1)-cnt);
-		printf("  %4d  %3d  %3d " ,da.t_cn, da.t_tn, da.t_sn);
-		if(vec)
-			printf("   %u\n", *(vec++));
-	}
+main(argc, argp) int argc;
+char *argp[];
+{
+  int cnt, cnt1;
+  char *ap;
+
+  argp++;
+  for (ap = *argp++; ap && *ap; ap++)
+    switch (*ap) {
+    case 'f':
+      coref = *argp++;
+      break;
+    case 'i':
+      interval = atoi(*argp++);
+      break;
+    case 'n':
+      infile = *argp++;
+      break;
+    case '-':
+      break;
+    default:
+      fprintf(stderr, "%s", usage);
+      exit(1);
+      break;
+    }
+  initmem();
+  while (1) {
+    lmem();
+    display();
+    if (interval)
+      sleep(interval);
+    else
+      exit(0);
+  }
 }
 
-btoa(bn)
-long bn;
+initmem() {
+  int cnt, cnt1;
+
+  nlist(infile, nli);
+  if ((mem = open(coref, 0)) <= 0) {
+    printf("badstat: FATAL : Could not open %s\n", coref);
+    exit(1);
+  }
+  if (nli[0].n_value) { /* Check for nhk */
+    lseek(mem, (long)nli[0].n_value, 0);
+    read(mem, &nhk, sizeof(nhk));
+  }
+  if ((nli[2].n_value) && (nli[1].n_value)) { /* Check for nhp */
+    lseek(mem, (long)nli[2].n_value, 0);
+    read(mem, &hp_index, MAXRH);
+    lseek(mem, (long)nli[1].n_value, 0);
+    read(mem, &hpn, MAXRH);
+    nhp = hpn[0];
+    nhm = hpn[1];
+    nhj = hpn[2];
+  }
+  if (nhk == 0 && nhp == 0 && nhm == 0 && nhj == 0) {
+    printf("badstat: W : No bad sector devices on system\n");
+    exit(0);
+  }
+  if (nhk) {
+    if (nli[3].n_value == 0)
+      nhk = 0;
+    else {
+
+      for (cnt = 0; cnt < nhk; cnt++) {
+        for (cnt1 = 0; cnt1 < 8; cnt1++) {
+          sprintf(dev, "/dev/hk%d%d", cnt, cnt1);
+          fd = open(dev, 0);
+          if (fd > 0) {
+            if (read(fd, &dev, 1) == 1)
+              hk_av |= (1 << cnt);
+            close(fd);
+            break;
+          }
+        }
+      }
+      for (cnt = 0; cnt < nhk; cnt++) {
+        if ((hk_bads[cnt] = malloc(sizeof(struct dkbad))) <= 0) {
+          printf("badstat: F : malloc failed");
+          printf(" for hk %d\n", cnt);
+          exit(1);
+        }
+      }
+      lseek(mem, (long)nli[5].n_value, 0);
+      for (cnt = 0; cnt < nhk; cnt++)
+        read(mem, &hk_dt[cnt], sizeof(int));
+    }
+  }
+  if (nhp) {
+    if (nli[4].n_value == 0)
+      nhp = 0;
+    else {
+
+      for (cnt = 0; cnt < nhp; cnt++) {
+        for (cnt1 = 0; cnt1 < 8; cnt1++) {
+          sprintf(dev, "/dev/hp%d%d", cnt, cnt1);
+          fd = open(dev, 0);
+          if (fd > 0) {
+            if (read(fd, &dev, 1) == 1)
+              hp_av |= (1 << cnt);
+            close(fd);
+            break;
+          }
+        }
+      }
+
+      for (cnt = 0; cnt < nhp; cnt++) {
+        if ((hp_bads[cnt] = malloc(sizeof(struct dkbad))) <= 0) {
+          printf("badstat: F : malloc failed");
+          printf(" for hp %d\n", cnt);
+          exit(1);
+        }
+      }
+      lseek(mem, (long)nli[6].n_value + hp_index[0], 0);
+      for (cnt = 0; cnt < nhp; cnt++)
+        read(mem, &hp_dt[cnt], sizeof(char));
+    }
+  }
+  if (nhm) {
+    if (nli[4].n_value == 0)
+      nhm = 0;
+    else {
+
+      for (cnt = 0; cnt < nhm; cnt++) {
+        for (cnt1 = 0; cnt1 < 8; cnt1++) {
+          sprintf(dev, "/dev/hm%d%d", cnt, cnt1);
+          fd = open(dev, 0);
+          if (fd > 0) {
+            if (read(fd, &dev, 1) == 1)
+              hm_av |= (1 << cnt);
+            close(fd);
+            break;
+          }
+        }
+      }
+
+      for (cnt = 0; cnt < nhm; cnt++) {
+        if ((hm_bads[cnt] = malloc(sizeof(struct dkbad))) <= 0) {
+          printf("badstat: F : malloc failed");
+          printf(" for hm %d\n", cnt);
+          exit(1);
+        }
+      }
+      lseek(mem, (long)nli[6].n_value + hp_index[1], 0);
+      for (cnt = 0; cnt < nhm; cnt++)
+        read(mem, &hm_dt[cnt], sizeof(char));
+    }
+  }
+  if (nhj) {
+    if (nli[4].n_value == 0)
+      nhj = 0;
+    else {
+
+      for (cnt = 0; cnt < nhj; cnt++) {
+        for (cnt1 = 0; cnt1 < 8; cnt1++) {
+          sprintf(dev, "/dev/hj%d%d", cnt, cnt1);
+          fd = open(dev, 0);
+          if (fd > 0) {
+            if (read(fd, &dev, 1) == 1)
+              hj_av |= (1 << cnt);
+            close(fd);
+            break;
+          }
+        }
+      }
+
+      for (cnt = 0; cnt < nhj; cnt++) {
+        if ((hj_bads[cnt] = malloc(sizeof(struct dkbad))) <= 0) {
+          printf("badstat: F : malloc failed");
+          printf(" for hj %d\n", cnt);
+          exit(1);
+        }
+      }
+      lseek(mem, (long)nli[6].n_value + hp_index[2], 0);
+      for (cnt = 0; cnt < nhj; cnt++)
+        read(mem, &hj_dt[cnt], sizeof(char));
+    }
+  }
+  if (hk_av == 0 && hp_av == 0 && hm_av == 0 && hj_av == 0) {
+    printf("badstat: F : No bad block info found\n");
+    exit(0);
+  }
+}
+
+lmem() {
+  int cnt, i;
+
+  if (nhk) {
+    lseek(mem, (long)nli[3].n_value, 0);
+    for (cnt = 0; cnt < nhk; cnt++) {
+      read(mem, hk_bads[cnt], sizeof(struct hkbad));
+    }
+  }
+  if (nhp) {
+    i = hp_index[0] * sizeof(struct hpbad);
+    lseek(mem, (long)nli[4].n_value + i, 0);
+    for (cnt = 0; cnt < nhp; cnt++) {
+      read(mem, hp_bads[cnt], sizeof(struct hpbad));
+    }
+  }
+  if (nhm) {
+    i = hp_index[1] * sizeof(struct hpbad);
+    lseek(mem, (long)nli[4].n_value + i, 0);
+    for (cnt = 0; cnt < nhm; cnt++) {
+      read(mem, hm_bads[cnt], sizeof(struct hpbad));
+    }
+  }
+  if (nhj) {
+    i = hp_index[2] * sizeof(struct hpbad);
+    lseek(mem, (long)nli[4].n_value + i, 0);
+    for (cnt = 0; cnt < nhj; cnt++) {
+      read(mem, hj_bads[cnt], sizeof(struct hpbad));
+    }
+  }
+}
+
+display() {
+
+  printf("\n\tBad Block Status on ");
+  date();
+  printf("\n");
+  if (hk_av) {
+    for (cnt = 0; cnt < nhk; cnt++) {
+      if (hk_av & (1 << cnt)) {
+        bp = hk_bads[cnt];
+        bt = &bp->bt_badb;
+        if ((dip = drvtyp(hk_dt[cnt])) == 0)
+          continue;
+        prtdev(-1, cnt);
+      }
+    }
+  }
+  if (hp_av) {
+    for (cnt = 0; cnt < nhp; cnt++) {
+      if (hp_av & (1 << cnt)) {
+        bp = hp_bads[cnt];
+        bt = &bp->bt_badb;
+        if ((dip = drvtyp(hp_dt[cnt])) == 0)
+          continue;
+        prtdev(0, cnt);
+      }
+    }
+  }
+  if (hm_av) {
+    for (cnt = 0; cnt < nhm; cnt++) {
+      if (hm_av & (1 << cnt)) {
+        bp = hm_bads[cnt];
+        bt = &bp->bt_badb;
+        if ((dip = drvtyp(hm_dt[cnt])) == 0)
+          continue;
+        prtdev(1, cnt);
+      }
+    }
+  }
+  if (hj_av) {
+    for (cnt = 0; cnt < nhj; cnt++) {
+      if (hj_av & (1 << cnt)) {
+        bp = hj_bads[cnt];
+        bt = &bp->bt_badb;
+        if ((dip = drvtyp(hj_dt[cnt])) == 0)
+          continue;
+        prtdev(2, cnt);
+      }
+    }
+  }
+}
+
+prtdev(ctrl, unit) {
+  int cnt;
+
+  if (ctrl >= 0)
+    printf("RH %d ", ctrl);
+  printf("%s Unit %d", dip->di_type, unit);
+  if ((bp->bt_csnh + bp->bt_csnl) == 0 || bp->bt_flag != 0 || bp->bt_mbz) {
+    printf("  NO VALID BAD SECTOR ");
+    printf("INFORMATION\n\n");
+    return;
+  }
+  dsk.seri[0] = bp->bt_csnh;
+  dsk.seri[1] = bp->bt_csnl;
+  printf("  Cartridge Serial #%D  Pack has ", dsk.serl);
+  for (cnt = 0, bt = &bp->bt_badb; cnt < dip->di_nsect; cnt++, bt++) {
+    if (bt->bt_cyl == -1 && bt->bt_trksec == -1)
+      break;
+    if (bt->bt_cyl == 0 && bt->bt_trksec == 0)
+      break;
+  }
+  if (cnt == 0) {
+    printf("NO bad sectors\n\n");
+    return;
+  }
+  printf("%d bad sectors\n\n", cnt);
+  bt = &bp->bt_badb;
+  printf("%s\n%s\n%s\n", bdhdr[0], bdhdr[1], bdhdr[2]);
+  prtsec(bp, bt, setvec());
+  printf("%s\n\n", bdhdr[2]);
+}
+
+prtsec(bp, bt, vec) struct dkbad *bp;
+struct bt_bad *bt;
+int *vec;
 {
-	da.t_cn = bn/(dip->di_ntrak*dip->di_nsect);
-	da.t_sn = bn%(dip->di_ntrak*dip->di_nsect);
-	da.t_tn = da.t_sn/dip->di_nsect;
-	da.t_sn = da.t_sn%dip->di_nsect;
+  int cnt;
+
+  for (cnt = 0; cnt < dip->di_nsect; cnt++, bt++) {
+    if (bt->bt_cyl == -1 && bt->bt_trksec == -1)
+      break;
+    if (bt->bt_cyl == 0 && bt->bt_trksec == 0)
+      break;
+    bn = atob(bt);
+    printf("%7D  %4d  %3d", bn, bt->bt_cyl, bt->bt_trksec >> 8);
+    printf("  %3d", bt->bt_trksec & 0377);
+    btoa((rbn - 1) - cnt);
+    printf("    %7D", (rbn - 1) - cnt);
+    printf("  %4d  %3d  %3d ", da.t_cn, da.t_tn, da.t_sn);
+    if (vec)
+      printf("   %u\n", *(vec++));
+  }
+}
+
+btoa(bn) long bn;
+{
+  da.t_cn = bn / (dip->di_ntrak * dip->di_nsect);
+  da.t_sn = bn % (dip->di_ntrak * dip->di_nsect);
+  da.t_tn = da.t_sn / dip->di_nsect;
+  da.t_sn = da.t_sn % dip->di_nsect;
 }
 
 long atob(bt)
 struct bt_bad *bt;
 {
-	long blkn;
+  long blkn;
 
-	blkn = (long)bt->bt_cyl * (long)(dip->di_ntrak * dip->di_nsect);
-	blkn += (long)((bt->bt_trksec >> 8) * dip->di_nsect);
-	blkn += ((long)bt->bt_trksec & 0377);
-	return(blkn);
+  blkn = (long)bt->bt_cyl * (long)(dip->di_ntrak * dip->di_nsect);
+  blkn += (long)((bt->bt_trksec >> 8) * dip->di_nsect);
+  blkn += ((long)bt->bt_trksec & 0377);
+  return (blkn);
 }
 
-drvtyp(type)
-int type;
+drvtyp(type) int type;
 {
-	register struct dkinfo *dp;
-	register struct dtype *dt;
+  register struct dkinfo *dp;
+  register struct dtype *dt;
 
-	for(dt = d_typ; dt->dtyp >= 0; dt++)
-		if(dt->dtyp == type)
-			break;
-	for(dp=dkinfo; dp->di_type; dp++)
-		if(strcmp(dp->di_type, dt->dname) == 0)
-			break;
-	if(dp->di_type == 0)
-		return(0);
-	rbn = dp->di_size - dp->di_nsect;
-	return(dp);
+  for (dt = d_typ; dt->dtyp >= 0; dt++)
+    if (dt->dtyp == type)
+      break;
+  for (dp = dkinfo; dp->di_type; dp++)
+    if (strcmp(dp->di_type, dt->dname) == 0)
+      break;
+  if (dp->di_type == 0)
+    return (0);
+  rbn = dp->di_size - dp->di_nsect;
+  return (dp);
 }
 
-date()
-{
-	register char *tzn;
-	struct timeb info;
-	struct tm *tp;
+date() {
+  register char *tzn;
+  struct timeb info;
+  struct tm *tp;
 
-	ftime(&info);
-	time(&timbuf);
-	tp = localtime(&timbuf);
-	ap = asctime(tp);
-	tzn = timezone(info.timezone, tp->tm_isdst);
-	printf("%.20s", ap);
-	if (tzn)
-		printf("%s", tzn);
-	printf("%s", ap+19);
+  ftime(&info);
+  time(&timbuf);
+  tp = localtime(&timbuf);
+  ap = asctime(tp);
+  tzn = timezone(info.timezone, tp->tm_isdst);
+  printf("%.20s", ap);
+  if (tzn)
+    printf("%s", tzn);
+  printf("%s", ap + 19);
 }
 
-setvec()
-{
-	if(strcmp(dip->di_name, "hk") == 0)
-		return(&bp->kbt_vec);
-	else if(strcmp(dip->di_name, "hp") == 0)
-		return(&bp->pbt_vec);
-	else
-		return(0);
+setvec() {
+  if (strcmp(dip->di_name, "hk") == 0)
+    return (&bp->kbt_vec);
+  else if (strcmp(dip->di_name, "hp") == 0)
+    return (&bp->pbt_vec);
+  else
+    return (0);
 }

--- a/src/cmd/basename.c
+++ b/src/cmd/basename.c
@@ -4,34 +4,43 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file basename.c
+ * @brief Strip directory names.
+ */
 
 static char Sccsid[] = "@(#)basename.c 3.0 4/21/86";
-#include	"stdio.h"
+#include "stdio.h"
 
-main(argc, argv)
-char **argv;
-{
-	register char *p1, *p2, *p3;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  register char *p1, *p2, *p3;
 
-	if (argc < 2) {
-		putchar('\n');
-		exit(1);
-	}
-	p1 = argv[1];
-	p2 = p1;
-	while (*p1) {
-		if (*p1++ == '/')
-			p2 = p1;
-	}
-	if (argc>2) {
-		for(p3=argv[2]; *p3; p3++) 
-			;
-		while(p3>argv[2])
-			if(p1 <= p2 || *--p3 != *--p1)
-				goto output;
-		*p1 = '\0';
-	}
+  if (argc < 2) {
+    putchar('\n');
+    exit(1);
+  }
+  p1 = argv[1];
+  p2 = p1;
+  while (*p1) {
+    if (*p1++ == '/')
+      p2 = p1;
+  }
+  if (argc > 2) {
+    for (p3 = argv[2]; *p3; p3++)
+      ;
+    while (p3 > argv[2])
+      if (p1 <= p2 || *--p3 != *--p1)
+        goto output;
+    *p1 = '\0';
+  }
 output:
-	fputs(p2, stdout);
-	exit(0);
+  fputs(p2, stdout);
+  exit(0);
 }

--- a/src/cmd/bfs.c
+++ b/src/cmd/bfs.c
@@ -4,6 +4,10 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file bfs.c
+ * @brief Big file scanner.
+ */
 
 static char Sccsid[] = "@(#)bfs.c 3.0 4/21/86";
 
@@ -16,67 +20,67 @@ jmp_buf env;
 
 #ifdef pdp11
 
-#define BRKTYP	char
-#define BRKSIZ	4096
-#define BRKTWO	2
-#define BFSAND	&0377
-#define BFSLIM	254
-#define BFSTRU	255
-#define BFSBUF	256
+#define BRKTYP char
+#define BRKSIZ 4096
+#define BRKTWO 2
+#define BFSAND &0377
+#define BFSLIM 254
+#define BFSTRU 255
+#define BFSBUF 256
 
 #else
 
-#define BRKTYP	short
-#define BRKSIZ	8192
-#define BRKTWO	4
+#define BRKTYP short
+#define BRKSIZ 8192
+#define BRKTWO 4
 #define BFSAND
-#define BFSLIM	511
-#define BFSTRU	511
-#define BFSBUF	512
+#define BFSLIM 511
+#define BFSTRU 511
+#define BFSBUF 512
 #endif
 
 /* The following 6 defines are necessary for the regexp.h routines. */
 
-#define INIT		register char *ptregx = instring;
-#define GETC()		(*ptregx++)
-#define PEEKC()		*ptregx
-#define UNGETC(c)	(--ptregx)
-#define RETURN(c)	return
-#define ERROR(c)	return((char *) regerr(c))
+#define INIT register char *ptregx = instring;
+#define GETC() (*ptregx++)
+#define PEEKC() *ptregx
+#define UNGETC(c) (--ptregx)
+#define RETURN(c) return
+#define ERROR(c) return ((char *)regerr(c))
 
 #include <regexp.h>
 
-#define REBUF	256
+#define REBUF 256
 
 struct Comd {
-	int Cnumadr;
-	int Cadr[2];
-	char Csep;
-	char Cop;
+  int Cnumadr;
+  int Cadr[2];
+  char Csep;
+  char Cop;
 };
 
 int Dot, Dollar;
-int circf1, circf2;	/* Save global variable "circf" from regexp.h */
+int circf1, circf2; /* Save global variable "circf" from regexp.h */
 int markarray[26], *mark;
-int fstack[15]={1, -1};
-int infildes=0;
-int outfildes=1;
+int fstack[15] = {1, -1};
+int infildes = 0;
+int outfildes = 1;
 char internal[512], *intptr;
 char comdlist[100];
-char *endds;		/* See brk(2) in manual. */
-char charbuf='\n';
+char *endds; /* See brk(2) in manual. */
+char charbuf = '\n';
 int peeked;
 char currex[100];
-int trunc=BFSTRU;
+int trunc = BFSTRU;
 int crunch = -1;
 int segblk[512], segoff[512], txtfd, prevblk, prevoff;
-int oldfd=0;
-int flag4=0;
-int flag3=0;
-int flag2=0;
-int flag1=0;
-int flag=0;
-int lprev=1;
+int oldfd = 0;
+int flag4 = 0;
+int flag3 = 0;
+int flag2 = 0;
+int flag1 = 0;
+int flag = 0;
+int lprev = 1;
 int status[1];
 
 BRKTYP *lincnt;
@@ -85,9 +89,9 @@ char rebuf[REBUF];
 char glbuf[REBUF];
 char tty, *bigfile;
 char fle[80];
-char prompt=1;
-char verbose=1;		/* 1=print # of bytes read in; 0=silent. */
-char varray[10][100];	/* Holds xv cmd parameters. */
+char prompt = 1;
+char verbose = 1;     /* 1=print # of bytes read in; 0=silent. */
+char varray[10][100]; /* Holds xv cmd parameters. */
 double outcnt;
 char strtmp[128];
 
@@ -98,1297 +102,1381 @@ char strtmp[128];
 ** used throughout the program.
 */
 typedef struct {
-	int	_cnt;
-	unsigned char	*_ptr;
-	unsigned char	*_base;
-	char	_flag;
-	char	_file;
+  int _cnt;
+  unsigned char *_ptr;
+  unsigned char *_base;
+  char _flag;
+  char _file;
 } FILE;
 extern FILE _iob[1];
-#define stdout	&_iob[1]
+#define stdout &_iob[1]
 
-main(argc,argv)
-int argc;
-char *argv[];
+main(argc, argv) int argc;
 {
-	extern reset();
-	struct Comd comdstruct, *p;
+  extern reset();
+  struct Comd comdstruct, *p;
 
-	if(argc < 2 || argc > 3) {
-		err(1,"bfs: arg count");
-		quit();
-	}
-	mark = markarray-'a';
-	if(argc == 3) verbose = 0;
-	setbuf(stdout, 0);
-	if(bigopen(bigfile=argv[argc-1])) quit();
-	tty = isatty(0);
+  if (argc < 2 || argc > 3) {
+    err(1, "bfs: arg count");
+    quit();
+  }
+  mark = markarray - 'a';
+  if (argc == 3)
+    verbose = 0;
+  setbuf(stdout, 0);
+  if (bigopen(bigfile = argv[argc - 1]))
+    quit();
+  tty = isatty(0);
 
-	p = &comdstruct;
-		/* Look for 0 or more non-'%' char followed by a '%' */
-	(char *)compile("[^%]*%",perbuf,&perbuf[REBUF],'\0');
-	circf1 = circf;		/* Save regexp.h flag */
-	setjmp(env);
-	signal(2,reset);
-	err(0,"");
-	printf("\n");
-	flag = 0;
-	prompt = 0;
-	while(1) begin(p);
+  p = &comdstruct;
+  /* Look for 0 or more non-'%' char followed by a '%' */
+  (char *)compile("[^%]*%", perbuf, &perbuf[REBUF], '\0');
+  circf1 = circf; /* Save regexp.h flag */
+  setjmp(env);
+  signal(2, reset);
+  err(0, "");
+  printf("\n");
+  flag = 0;
+  prompt = 0;
+  while (1)
+    begin(p);
 }
 
-reset()		/* for longjmp on signal */
+reset() /* for longjmp on signal */
 {
-	longjmp(env,1);
-}
- 
-
-begin(p)
-struct Comd *p;
-{
-	char line[256];
-
-strtagn:	if(flag == 0) eat();
-	if(infildes != 100) {
-		if(infildes == 0 && prompt) printf("*");
-		flag3 = 1;
-		getstr(1,line,0,0,0);
-		flag3 = 0;
-		if(percent(line) < 0) goto strtagn;
-		newfile(1,"");
-	}
-	if(!(getcomd(p,1) < 0)) {
-
-	switch(p->Cop) {
-
-		case 'e':	if(!flag) ecomd(p);
-				else err(0,"");
-				break;
-
-		case 'f':	fcomd(p);
-				break;
-
-		case 'g':	if(flag == 0) gcomd(p,1);
-				else err(0,"");
-				break;
-
-		case 'k':	kcomd(p);
-				break;
-
-		case 'p':	pcomd(p);
-				break;
-
-		case 'q':	qcomd(p);
-				break;
-
-		case 'v':	if(flag == 0) gcomd(p,0);
-				else err(0,"");
-				break;
-
-		case 'x':	if(!flag) xcomds(p);
-				else err(0,"");
-				break;
-
-		case 'w':	wcomd(p);
-				break;
-
-		case '\n':	nlcomd(p);
-				break;
-
-		case '=':	eqcomd(p);
-				break;
-
-		case ':':	colcomd(p);
-				break;
-
-		case '!':	excomd(p);
-				break;
-
-		case 'P':	prompt = !prompt;
-				break;
-
-
-		default:	if(flag) err(0,"");
-				else err(1,"bad command");
-				break;
-	}
-	}
+  longjmp(env, 1);
 }
 
-
-bigopen(file)
-char file[];
+begin(p) struct Comd *p;
 {
-	register int l, off, cnt;
-	int blk, newline, n, s;
-	char block[512];
+  char line[256];
 
-	if((txtfd=open(file,0)) < 0) {
-		sprintf(strtmp, "bfs: cannot open %s", file);
-		return(err(1,strtmp));
-	}
-	blk = -1;
-	newline = 1;
-	l = cnt = s = 0;
-	off = 512;
-	if((lincnt=(BRKTYP*)sbrk(BRKSIZ)) == (BRKTYP*)-1)
-		return(err(1,"bfs: too many lines"));
-	endds = (char *)lincnt;	/* Save initial data space address. */
+strtagn:
+  if (flag == 0)
+    eat();
+  if (infildes != 100) {
+    if (infildes == 0 && prompt)
+      printf("*");
+    flag3 = 1;
+    getstr(1, line, 0, 0, 0);
+    flag3 = 0;
+    if (percent(line) < 0)
+      goto strtagn;
+    newfile(1, "");
+  }
+  if (!(getcomd(p, 1) < 0)) {
 
-	while((n=read(txtfd,block,512)) > 0) {
-		blk++;
-		for(off=0; off<n; off++) {
-			if(newline) {
-				newline = 0;
-				if(l>0 && !(l&07777))
-					if(sbrk(BRKSIZ) == -1)
-					  return(err(1,"bfs: too many lines"));
-				lincnt[l] = cnt;
-				cnt = 0;
-				if(!(l++ & 077)) {
-					segblk[s] = blk;
-					segoff[s++] = off;
-				}
-				if(l < 0 || l > 32767) return(err(1,"bfs: too many lines"));
-			}
-			if(block[off] == '\n') newline = 1;
-			cnt++;
+    switch (p->Cop) {
+
+    case 'e':
+      if (!flag)
+        ecomd(p);
+      else
+        err(0, "");
+      break;
+
+    case 'f':
+      fcomd(p);
+      break;
+
+    case 'g':
+      if (flag == 0)
+        gcomd(p, 1);
+      else
+        err(0, "");
+      break;
+
+    case 'k':
+      kcomd(p);
+      break;
+
+    case 'p':
+      pcomd(p);
+      break;
+
+    case 'q':
+      qcomd(p);
+      break;
+
+    case 'v':
+      if (flag == 0)
+        gcomd(p, 0);
+      else
+        err(0, "");
+      break;
+
+    case 'x':
+      if (!flag)
+        xcomds(p);
+      else
+        err(0, "");
+      break;
+
+    case 'w':
+      wcomd(p);
+      break;
+
+    case '\n':
+      nlcomd(p);
+      break;
+
+    case '=':
+      eqcomd(p);
+      break;
+
+    case ':':
+      colcomd(p);
+      break;
+
+    case '!':
+      excomd(p);
+      break;
+
+    case 'P':
+      prompt = !prompt;
+      break;
+
+    default:
+      if (flag)
+        err(0, "");
+      else
+        err(1, "bad command");
+      break;
+    }
+  }
+}
+
+bigopen(file) char file[];
+{
+  register int l, off, cnt;
+  int blk, newline, n, s;
+  char block[512];
+
+  if ((txtfd = open(file, 0)) < 0) {
+    sprintf(strtmp, "bfs: cannot open %s", file);
+    return (err(1, strtmp));
+  }
+  blk = -1;
+  newline = 1;
+  l = cnt = s = 0;
+  off = 512;
+  if ((lincnt = (BRKTYP *)sbrk(BRKSIZ)) == (BRKTYP *)-1)
+    return (err(1, "bfs: too many lines"));
+  endds = (char *)lincnt; /* Save initial data space address. */
+
+  while ((n = read(txtfd, block, 512)) > 0) {
+    blk++;
+    for (off = 0; off < n; off++) {
+      if (newline) {
+        newline = 0;
+        if (l > 0 && !(l & 07777))
+          if (sbrk(BRKSIZ) == -1)
+            return (err(1, "bfs: too many lines"));
+        lincnt[l] = cnt;
+        cnt = 0;
+        if (!(l++ & 077)) {
+          segblk[s] = blk;
+          segoff[s++] = off;
+        }
+        if (l < 0 || l > 32767)
+          return (err(1, "bfs: too many lines"));
+      }
+      if (block[off] == '\n')
+        newline = 1;
+      cnt++;
 #ifdef pdp11
-			if(cnt > 255)
-				{printf("Line %d too long\n",l);
-				return(-1);
-				}
+      if (cnt > 255) {
+        printf("Line %d too long\n", l);
+        return (-1);
+      }
 #endif
-		}
-	}
-	if(!(l&07777)) if(sbrk(BRKTWO) == -1)
-		return(err(1,"bfs: too many lines"));
-	lincnt[Dot = Dollar = l] = cnt;
-	sizeprt(blk,off);
-	return(0);
+    }
+  }
+  if (!(l & 07777))
+    if (sbrk(BRKTWO) == -1)
+      return (err(1, "bfs: too many lines"));
+  lincnt[Dot = Dollar = l] = cnt;
+  sizeprt(blk, off);
+  return (0);
 }
 
-
-sizeprt(blk, off)
-int blk, off;
+sizeprt(blk, off) int blk, off;
 {
-	if(verbose) printf("%.0f",512.*blk+off);
+  if (verbose)
+    printf("%.0f", 512. * blk + off);
 }
-
 
 int saveblk = -1;
 
-
-bigread(l,rec)
-int l;
+bigread(l, rec) int l;
 char rec[];
 {
-	register int i;
-	register char *r, *b;
-	int off;
-	static char savetxt[512];
+  register int i;
+  register char *r, *b;
+  int off;
+  static char savetxt[512];
 
-	if((i=l-lprev) == 1) prevoff += lincnt[lprev]BFSAND;
-	else if(i >= 0 && i <= 32)
-		for(i=lprev; i<l; i++) prevoff += lincnt[i]BFSAND;
-	else if(i < 0 && i >= -32)
-		for(i=lprev-1; i>=l; i--) prevoff -= lincnt[i]BFSAND;
-	else {
-		prevblk = segblk[i=(l-1)>>6];
-		prevoff = segoff[i];
-		for(i=(i<<6)+1; i<l; i++) prevoff += lincnt[i]BFSAND;
-	}
+  if ((i = l - lprev) == 1)
+    prevoff += lincnt[lprev] BFSAND;
+  else if (i >= 0 && i <= 32)
+    for (i = lprev; i < l; i++)
+      prevoff += lincnt[i] BFSAND;
+  else if (i < 0 && i >= -32)
+    for (i = lprev - 1; i >= l; i--)
+      prevoff -= lincnt[i] BFSAND;
+  else {
+    prevblk = segblk[i = (l - 1) >> 6];
+    prevoff = segoff[i];
+    for (i = (i << 6) + 1; i < l; i++)
+      prevoff += lincnt[i] BFSAND;
+  }
 
-	prevblk += prevoff>>9;
-	prevoff &= 0777;
-	lprev = l;
+  prevblk += prevoff >> 9;
+  prevoff &= 0777;
+  lprev = l;
 
-	if(prevblk != saveblk) {
-		lseek(txtfd,((long)(saveblk=prevblk))<<9,0);
-		read(txtfd,savetxt,512);
-	}
+  if (prevblk != saveblk) {
+    lseek(txtfd, ((long)(saveblk = prevblk)) << 9, 0);
+    read(txtfd, savetxt, 512);
+  }
 
-	r = rec;
-	off = prevoff;
-	while(1) {
-		for(b=savetxt+off; b<savetxt+512; b++) {
-			if((*r++ = *b) == '\n') {
-				*(r-1) = '\0';
-				return;
-			}
-			if(((unsigned)r - (unsigned)rec) > BFSLIM) {
+  r = rec;
+  off = prevoff;
+  while (1) {
+    for (b = savetxt + off; b < savetxt + 512; b++) {
+      if ((*r++ = *b) == '\n') {
+        *(r - 1) = '\0';
+        return;
+      }
+      if (((unsigned)r - (unsigned)rec) > BFSLIM) {
 #ifdef pdp11
-				write(2, "line too long\n", 14);
-				exit(1);
+        write(2, "line too long\n", 14);
+        exit(1);
 #else
-				write(2, "Line too long--output truncated\n", 32);
-				return;
+        write(2, "Line too long--output truncated\n", 32);
+        return;
 #endif
-			}
-		}
-		read(txtfd,savetxt,512);
-		off = 0;
-		saveblk++;
-	}
+      }
+    }
+    read(txtfd, savetxt, 512);
+    off = 0;
+    saveblk++;
+  }
 }
 
+ecomd(p) struct Comd *p;
+{
+  register int i = 0;
 
-ecomd(p)
+  while (peekc() == ' ')
+    getc();
+  while ((fle[i++] = getc()) != '\n')
+    ;
+  fle[--i] = '\0';
+  close(txtfd); /* Without this, ~20 "e" cmds gave "can't open" msg. */
+  brk(endds);   /* Reset data space addr. - mostly for 16-bit cpu's. */
+  lprev = 1;
+  prevblk = 0;
+  prevoff = 0;
+  saveblk = -1; /* Reset parameters. */
+  if (bigopen(bigfile = fle))
+    quit();
+  printf("\n");
+}
+
+fcomd(p) struct Comd *p;
+{
+  if (more() || defaults(p, 1, 0, 0, 0, 0, 0))
+    return (-1);
+  printf("%s\n", bigfile);
+  return (0);
+}
+
+gcomd(p, k) int k;
 struct Comd *p;
 {
-	register int i = 0;
+  register char d;
+  register int i, end;
+  char line[BFSBUF], *ptr;
 
-	while(peekc() == ' ') getc();
-	while((fle[i++] = getc()) != '\n');
-	fle[--i] = '\0';
-	close(txtfd);	/* Without this, ~20 "e" cmds gave "can't open" msg. */
-	brk(endds);	/* Reset data space addr. - mostly for 16-bit cpu's. */
-	lprev=1; prevblk=0; prevoff=0; saveblk = -1;	/* Reset parameters. */
-	if(bigopen(bigfile =fle)) quit();
-	printf("\n");
+  if (defaults(p, 1, 2, 1, Dollar, 0, 0))
+    return (-1);
+
+  if ((d = getc()) == '\n')
+    return (err(1, "syntax"));
+  if (peekc() == d)
+    getc();
+  else if (getstr(1, currex, d, 0, 1))
+    return (-1);
+  if ((ptr = (char *)compile(currex, glbuf, &glbuf[REBUF], '\0')) == (char *)-1)
+    return (err(1, "RE-syntax"));
+  circf2 = circf;
+
+  if (getstr(1, comdlist, 0, 0, 0))
+    return (-1);
+  i = p->Cadr[0];
+  end = p->Cadr[1];
+  while (i <= end) {
+    bigread(i, line);
+    circf = circf2; /* Restore circf for "step()" */
+    if (!(step(line, glbuf))) {
+      if (!k) {
+        Dot = i;
+        if (xcomdlist(p))
+          return (err(1, "bad comd list"));
+      }
+      i++;
+    } else {
+      if (k) {
+        Dot = i;
+        if (xcomdlist(p))
+          return (err(1, "bad comd list"));
+      }
+      i++;
+    }
+  }
+  return (0);
 }
 
-fcomd(p)
-struct Comd *p;
+kcomd(p) struct Comd *p;
 {
-	if(more() || defaults(p,1,0,0,0,0,0)) return(-1);
-	printf("%s\n",bigfile);
-	return(0);
+  register char c;
+
+  if ((c = peekc()) < 'a' || c > 'z')
+    return (err(1, "bad mark"));
+  getc();
+  if (more() || defaults(p, 1, 1, Dot, 0, 1, 0))
+    return (-1);
+
+  mark[c] = Dot = p->Cadr[0];
+  return (0);
 }
 
-
-gcomd(p,k)
-int k;
-struct Comd *p;
+xncomd(p) struct Comd *p;
 {
-	register char d;
-	register int i, end;
-	char line[BFSBUF], *ptr;
+  register char c;
 
-	if(defaults(p,1,2,1,Dollar,0,0)) return(-1);
+  if (more() || defaults(p, 1, 0, 0, 0, 0, 0))
+    return (-1);
 
-	if((d=getc()) == '\n') return(err(1,"syntax"));
-	if(peekc() == d) getc();
-	else 
-		if(getstr(1,currex,d,0,1)) return(-1);
-	if((ptr = (char *) compile(currex,glbuf,&glbuf[REBUF],'\0')) == (char *) -1)
-		return(err(1,"RE-syntax"));
-	circf2 = circf;
+  for (c = 'a'; c <= 'z'; c++)
+    if (mark[c])
+      printf("%c\n", c);
 
-	if(getstr(1,comdlist,0,0,0)) return(-1);
-	i = p->Cadr[0];
-	end = p->Cadr[1];
-	while (i<=end) {
-		bigread(i,line);
-		circf = circf2;		/* Restore circf for "step()" */
-		if(!(step(line,glbuf))) {
-			if(!k) {
-				Dot = i;
-				if (xcomdlist(p)) return(err(1,"bad comd list"));
-			}
-			i++;
-		}
-		else {
-			if(k) {
-				Dot = i;
-				if (xcomdlist(p)) return(err(1,"bad comd list"));
-			}
-			i++;
-		}
-	}
-	return(0);
+  return (0);
 }
 
-
-kcomd(p)
-struct Comd *p;
+pcomd(p) struct Comd *p;
 {
-	register char c;
+  register int i;
+  char line[BFSBUF];
 
-	if((c=peekc()) < 'a' || c > 'z') return(err(1,"bad mark"));
-	getc();
-	if(more() || defaults(p,1,1,Dot,0,1,0)) return(-1);
+  if (more() || defaults(p, 1, 2, Dot, Dot, 1, 0))
+    return (-1);
 
-	mark[c] = Dot = p->Cadr[0];
-	return(0);
+  for (i = p->Cadr[0]; i <= p->Cadr[1] && i > 0; i++) {
+    bigread(i, line);
+    out(line);
+  }
+  return (0);
 }
 
-
-xncomd(p)
-struct Comd *p;
+qcomd(p) struct Comd *p;
 {
-	register char c;
-
-	if(more() || defaults(p,1,0,0,0,0,0)) return(-1);
-
-	for(c='a'; c<='z'; c++)
-		if(mark[c]) printf("%c\n",c);
-
-	return(0);
+  if (more())
+    return (-1);
+  quit();
 }
 
-
-pcomd(p)
-struct Comd *p;
+xcomds(p) struct Comd *p;
 {
-	register int i;
-	char line[BFSBUF];
-
-	if(more() || defaults(p,1,2,Dot,Dot,1,0)) return(-1);
-
-	for(i=p->Cadr[0]; i<=p->Cadr[1] && i>0; i++) {
-		bigread(i,line);
-		out(line);
-	}
-	return(0);
+  switch (getc()) {
+  case 'b':
+    return (xbcomd(p));
+  case 'c':
+    return (xccomd(p));
+  case 'f':
+    return (xfcomd(p));
+  case 'n':
+    return (xncomd(p));
+  case 'o':
+    return (xocomd(p));
+  case 't':
+    return (xtcomd(p));
+  case 'v':
+    return (xvcomd(p));
+  default:
+    return (err(1, "bad command"));
+  }
 }
 
-
-qcomd(p)
-struct Comd *p;
+xbcomd(p) struct Comd *p;
 {
-	if(more()) return(-1);
-	quit();
+  register int fail, n;
+  register char d;
+  char str[50];
+
+  fail = 0;
+  if (defaults(p, 0, 2, Dot, Dot, 0, 1))
+    fail = 1;
+  else {
+    if ((d = getc()) == '\n')
+      return (err(1, "syntax"));
+    if (d == 'z') {
+      if (status[0] != 0)
+        return (0);
+      getc();
+      if (getstr(1, str, 0, 0, 0))
+        return (-1);
+      return (jump(1, str));
+    }
+    if (d == 'n') {
+      if (status[0] == 0)
+        return (0);
+      getc();
+      if (getstr(1, str, 0, 0, 0))
+        return (-1);
+      return (jump(1, str));
+    }
+    if (getstr(1, str, d, ' ', 0))
+      return (-1);
+    if ((n = hunt(0, str, p->Cadr[0] - 1, 1, 0, 1)) < 0)
+      fail = 1;
+    if (getstr(1, str, 0, 0, 0))
+      return (-1);
+    if (more())
+      return (err(1, "syntax"));
+  }
+
+  if (!fail) {
+    Dot = n;
+    return (jump(1, str));
+  }
+  return (0);
 }
 
-
-xcomds(p)
-struct Comd *p;
+xccomd(p) struct Comd *p;
 {
-	switch(getc()) {
-		case 'b':	return(xbcomd(p));
-		case 'c':	return(xccomd(p));
-		case 'f':	return(xfcomd(p));
-		case 'n':	return(xncomd(p));
-		case 'o':	return(xocomd(p));
-		case 't':	return(xtcomd(p));
-		case 'v':	return(xvcomd(p));
-		default:	return(err(1,"bad command"));
-	}
+  char arg[100];
+
+  if (getstr(1, arg, 0, ' ', 0) || defaults(p, 1, 0, 0, 0, 0, 0))
+    return (-1);
+
+  if (equal(arg, ""))
+    crunch = -crunch;
+  else if (equal(arg, "0"))
+    crunch = -1;
+  else if (equal(arg, "1"))
+    crunch = 1;
+  else
+    return (err(1, "syntax"));
+
+  return (0);
 }
 
-
-xbcomd(p)
-struct Comd *p;
+xfcomd(p) struct Comd *p;
 {
-	register int fail, n;
-	register char d;
-	char str[50];
+  char fl[100];
+  register char *f;
 
-	fail = 0;
-	if(defaults(p,0,2,Dot,Dot,0,1)) fail = 1;
-	else {
-		if((d=getc()) == '\n') return(err(1,"syntax"));
-		if(d == 'z') {
-			if(status[0] != 0) return(0);
-			getc();
-			if(getstr(1,str,0,0,0)) return(-1);
-			return(jump(1,str));
-		}
-		if(d == 'n') {
-			if(status[0] == 0) return(0);
-			getc();
-			if(getstr(1,str,0,0,0)) return(-1);
-			return(jump(1,str));
-		}
-		if(getstr(1,str,d,' ',0)) return(-1);
-		if((n=hunt(0,str,p->Cadr[0]-1,1,0,1)) < 0) fail = 1;
-		if(getstr(1,str,0,0,0)) return(-1);
-		if(more()) return(err(1,"syntax"));
-	}
+  if (defaults(p, 1, 0, 0, 0, 0, 0))
+    return (-1);
 
-	if(!fail) {
-		Dot = n;
-		return(jump(1,str));
-	}
-	return(0);
+  while (peekc() == ' ')
+    getc();
+  for (f = fl; (*f = getc()) != '\n'; f++)
+    ;
+  if (f == fl)
+    return (err(1, "no file"));
+  *f = '\0';
+
+  return (newfile(1, fl));
 }
 
-
-xccomd(p)
-struct Comd *p;
+xocomd(p) struct Comd *p;
 {
-	char arg[100];
+  register int fd;
+  char arg[100];
 
-	if(getstr(1,arg,0,' ',0) || defaults(p,1,0,0,0,0,0)) return(-1);
+  if (getstr(1, arg, 0, ' ', 0) || defaults(p, 1, 0, 0, 0, 0, 0))
+    return (-1);
 
-	if(equal(arg,"")) crunch = -crunch;
-	else if(equal(arg,"0")) crunch = -1;
-	else if(equal(arg,"1")) crunch = 1;
-	else return(err(1,"syntax"));
-
-	return(0);
+  if (!arg[0]) {
+    if (outfildes == 1)
+      return (err(1, "no diversion"));
+    close(outfildes);
+    outfildes = 1;
+  } else {
+    if (outfildes != 1)
+      return (err(1, "already diverted"));
+    if ((fd = creat(arg, 0666)) < 0) {
+      sprintf(strtmp, "bfs: cannot create %s", arg);
+      return (err(1, strtmp));
+    }
+    outfildes = fd;
+  }
+  return (0);
 }
 
-
-xfcomd(p)
-struct Comd *p;
+xtcomd(p) struct Comd *p;
 {
-	char fl[100];
-	register char *f;
+  register int t;
 
-	if(defaults(p,1,0,0,0,0,0)) return(-1);
+  while (peekc() == ' ')
+    getc();
+  if ((t = rdnumb(1)) < 0 || more() || defaults(p, 1, 0, 0, 0, 0, 0))
+    return (-1);
 
-	while(peekc() == ' ') getc();
-	for(f=fl; (*f=getc()) != '\n'; f++);
-	if(f==fl) return(err(1,"no file"));
-	*f = '\0';
-
-	return(newfile(1,fl));
+  trunc = t;
+  return (0);
 }
 
-
-xocomd(p)
-struct Comd *p;
+xvcomd(p) struct Comd *p;
 {
-	register int fd;
-	char arg[100];
+  register char c;
+  register int i;
+  int temp0, temp1, temp2;
+  int fildes[2];
 
-	if(getstr(1,arg,0,' ',0) || defaults(p,1,0,0,0,0,0)) return(-1);
-
-	if(!arg[0]) {
-		if(outfildes == 1) return(err(1,"no diversion"));
-		close(outfildes);
-		outfildes = 1;
-	}
-	else {
-		if(outfildes != 1) return(err(1,"already diverted"));
-		if((fd=creat(arg,0666)) < 0) {
-			sprintf(strtmp, "bfs: cannot create %s", arg);
-			return(err(1, strtmp));
-		}
-		outfildes = fd;
-	}
-	return(0);
+  if ((c = peekc()) < '0' || c > '9')
+    return (err(1, "digit required"));
+  getc();
+  c -= '0';
+  while (peekc() == ' ')
+    getc();
+  if (peekc() == '\\')
+    getc();
+  else if (peekc() == '!') {
+    if (pipe(fildes) < 0) {
+      printf("Try again");
+      return;
+    }
+    temp0 = dup(0);
+    temp1 = dup(1);
+    temp2 = infildes;
+    close(0);
+    dup(fildes[0]);
+    close(1);
+    dup(fildes[1]);
+    close(fildes[0]);
+    close(fildes[1]);
+    getc();
+    flag4 = 1;
+    excomd(p);
+    close(1);
+    infildes = 0;
+  }
+  for (i = 0; (varray[c][i] = getc()) != '\n'; i++)
+    ;
+  varray[c][i] = '\0';
+  if (flag4) {
+    infildes = temp2;
+    close(0);
+    dup(temp0);
+    close(temp0);
+    dup(temp1);
+    close(temp1);
+    flag4 = 0;
+    charbuf = ' ';
+  }
+  return (0);
 }
 
-
-xtcomd(p)
-struct Comd *p;
+wcomd(p) struct Comd *p;
 {
-	register int t;
+  register int i, fd, savefd;
+  int savecrunch, savetrunc;
+  char arg[100], line[256];
 
-	while(peekc() == ' ') getc();
-	if((t=rdnumb(1)) < 0 || more() || defaults(p,1,0,0,0,0,0))
-		return(-1);
+  if (getstr(1, arg, 0, ' ', 0) || defaults(p, 1, 2, 1, Dollar, 1, 0))
+    return (-1);
+  if (!arg[0])
+    return (err(1, "bfs: no file name"));
+  if (equal(arg, bigfile))
+    return (err(1, "no change indicated"));
+  if ((fd = creat(arg, 0666)) < 0) {
+    sprintf(strtmp, "bfs: cannot create %s", arg);
+    return (err(1, strtmp));
+  }
+  savefd = outfildes;
+  savetrunc = trunc;
+  savecrunch = crunch;
+  outfildes = fd;
+  trunc = BFSTRU;
+  crunch = -1;
 
-	trunc = t;
-	return(0);
+  outcnt = 0;
+  for (i = p->Cadr[0]; i <= p->Cadr[1] && i > 0; i++) {
+    bigread(i, line);
+    out(line);
+  }
+  if (verbose)
+    printf("%.0f\n", outcnt);
+  close(fd);
+
+  outfildes = savefd;
+  trunc = savetrunc;
+  crunch = savecrunch;
+  return (0);
 }
 
-
-xvcomd(p)
-struct Comd *p;
+nlcomd(p) struct Comd *p;
 {
-	register char c;
-	register int i;
-	int temp0, temp1, temp2;
-	int fildes[2];
-
-	if((c=peekc()) < '0' || c > '9') return(err(1,"digit required"));
-	getc();
-	c -= '0';
-	while(peekc() == ' ') getc();
-	if(peekc()=='\\') getc();
-	else if(peekc() == '!') {
-		if(pipe(fildes) < 0) {
-			printf("Try again");
-			return;
-		}
-		temp0 = dup(0);
-		temp1 = dup(1);
-		temp2 = infildes;
-		close(0);
-		dup(fildes[0]);
-		close(1);
-		dup(fildes[1]);
-		close(fildes[0]);
-		close(fildes[1]);
-		getc();
-		flag4 = 1;
-		excomd(p);
-		close(1);
-		infildes = 0;
-	}
-	for(i=0;(varray[c][i] = getc()) != '\n';i++);
-	varray[c][i] = '\0';
-	if(flag4) {
-		infildes = temp2;
-		close(0);
-		dup(temp0);
-		close(temp0);
-		dup(temp1);
-		close(temp1);
-		flag4 = 0;
-		charbuf = ' ';
-	}
-	return(0);
+  if (defaults(p, 1, 2, Dot + 1, Dot + 1, 1, 0)) {
+    getc();
+    return (-1);
+  }
+  return (pcomd(p));
 }
 
-
-wcomd(p)
-struct Comd *p;
+eqcomd(p) struct Comd *p;
 {
-	register int i, fd, savefd;
-	int savecrunch, savetrunc;
-	char arg[100], line[256];
-
-	if(getstr(1,arg,0,' ',0) || defaults(p,1,2,1,Dollar,1,0)) return(-1);
-	if(!arg[0]) return(err(1,"bfs: no file name"));
-	if(equal(arg,bigfile)) return(err(1,"no change indicated"));
-	if((fd=creat(arg,0666)) <0) {
-		sprintf(strtmp, "bfs: cannot create %s", arg);
-		return(err(1, strtmp));
-	}
-	savefd = outfildes;
-	savetrunc = trunc;
-	savecrunch = crunch;
-	outfildes = fd;
-	trunc = BFSTRU;
-	crunch = -1;
-
-	outcnt = 0;
-	for(i=p->Cadr[0]; i<=p->Cadr[1] && i>0; i++) {
-		bigread(i,line);
-		out(line);
-	}
-	if(verbose) printf("%.0f\n",outcnt);
-	close(fd);
-
-	outfildes = savefd;
-	trunc = savetrunc;
-	crunch = savecrunch;
-	return(0);
+  if (more() || defaults(p, 1, 1, Dollar, 0, 0, 0))
+    return (-1);
+  printf("%d\n", p->Cadr[0]);
 }
 
-
-nlcomd(p)
-struct Comd *p;
+colcomd(p) struct Comd *p;
 {
-	if(defaults(p,1,2,Dot+1,Dot+1,1,0)) {
-		getc();
-		return(-1);
-	}
-	return(pcomd(p));
+  return (defaults(p, 1, 0, 0, 0, 0, 0));
 }
 
-
-eqcomd(p)
-struct Comd *p;
+xcomdlist(p) struct Comd *p;
 {
-	if(more() || defaults(p,1,1,Dollar,0,0,0)) return(-1);
-	printf("%d\n",p->Cadr[0]);
+  flag = 1;
+  flag2 = 1;
+  newfile(1, "");
+  while (flag2)
+    begin(p);
+  if (flag == 0)
+    return (1);
+  flag = 0;
+  return (0);
 }
 
-
-colcomd(p)
-struct Comd *p;
+excomd(p) struct Comd *p;
 {
-	return(defaults(p,1,0,0,0,0,0));
+  register int i;
+
+  if (infildes != 100)
+    charbuf = '\n';
+  while ((i = fork()) < 0)
+    sleep(10);
+  if (!i) {
+    signal(SIGINT, SIG_DFL); /*Guarantees child can be intr. */
+    if (infildes == 100 || flag4) {
+      execl("/bin/sh", "sh", "-c", intptr, 0);
+      exit();
+    }
+    if (infildes != 0) {
+      close(0);
+      dup(infildes);
+    }
+    for (i = 3; i < 15; i++)
+      close(i);
+    execl("/bin/sh", "sh", "-t", 0);
+    exit();
+  }
+  signal(SIGINT, SIG_IGN);
+  while (wait(status) != i)
+    ;
+  status[0] = status[0] >> 8;
+  signal(SIGINT, reset); /* Restore signal to previous status */
+
+  if ((infildes == 0 || (infildes == 100 && fstack[fstack[0]] == 0)) &&
+      verbose && (!flag4))
+    printf("!\n");
+  return (0);
 }
 
-
-xcomdlist(p)
-struct Comd *p;
-{
-	flag = 1;
-	flag2 = 1;
-	newfile(1,"");
-	while(flag2) begin(p);
-	if(flag == 0) return(1);
-	flag = 0;
-	return(0);
-}
-
-
-excomd(p)
-struct Comd *p;
-{
-	register int i;
-
-	if(infildes != 100) charbuf = '\n';
-	while((i=fork()) < 0) sleep(10);
-	if(!i) {
-		signal(SIGINT, SIG_DFL); /*Guarantees child can be intr. */
-		if(infildes == 100 || flag4) {
-			execl("/bin/sh","sh","-c",intptr,0);
-			exit();
-		}
-		if(infildes != 0) {
-			close(0);
-			dup(infildes);
-		}
-		for(i=3; i<15; i++) close(i);
-		execl("/bin/sh","sh","-t",0);
-		exit();
-	}
-	signal(SIGINT, SIG_IGN);
-	while(wait(status) != i);
-	status[0] = status[0] >> 8;
-	signal(SIGINT, reset);	/* Restore signal to previous status */
-
-	if((infildes == 0 || (infildes  == 100 && fstack[fstack[0]] == 0))
-				&& verbose && (!flag4)) printf("!\n");
-	return(0);
-}
-
-
-defaults(p,prt,max,def1,def2,setdot,errsok)
-struct Comd *p;
+defaults(p, prt, max, def1, def2, setdot, errsok) struct Comd *p;
 int prt, max, def1, def2, setdot, errsok;
 {
-	if(!def1) def1 = Dot;
-	if(!def2) def2 = def1;
-	if(p->Cnumadr >= max) return(errsok?-1:err(prt,"adr count"));
-	if(p->Cnumadr < 0) {
-		p->Cadr[++p->Cnumadr] = def1;
-		p->Cadr[++p->Cnumadr] = def2;
-	}
-	else if(p->Cnumadr < 1)
-		p->Cadr[++p->Cnumadr] = p->Cadr[0];
-	if(p->Cadr[0] < 1 || p->Cadr[0] > Dollar ||
-	   p->Cadr[1] < 1 || p->Cadr[1] > Dollar)
-		return(errsok?-1:err(prt,"range"));
-	if(p->Cadr[0] > p->Cadr[1]) return(errsok?-1:err(prt,"adr1 > adr2"));
-	if(setdot) Dot = p->Cadr[1];
-	return(0);
+  if (!def1)
+    def1 = Dot;
+  if (!def2)
+    def2 = def1;
+  if (p->Cnumadr >= max)
+    return (errsok ? -1 : err(prt, "adr count"));
+  if (p->Cnumadr < 0) {
+    p->Cadr[++p->Cnumadr] = def1;
+    p->Cadr[++p->Cnumadr] = def2;
+  } else if (p->Cnumadr < 1)
+    p->Cadr[++p->Cnumadr] = p->Cadr[0];
+  if (p->Cadr[0] < 1 || p->Cadr[0] > Dollar || p->Cadr[1] < 1 ||
+      p->Cadr[1] > Dollar)
+    return (errsok ? -1 : err(prt, "range"));
+  if (p->Cadr[0] > p->Cadr[1])
+    return (errsok ? -1 : err(prt, "adr1 > adr2"));
+  if (setdot)
+    Dot = p->Cadr[1];
+  return (0);
 }
 
-
-getcomd(p,prt)
-struct Comd *p;
+getcomd(p, prt) struct Comd *p;
 int prt;
 {
-	register int r;
-	register char c;
+  register int r;
+  register char c;
 
-	p->Cnumadr = -1;
-	p->Csep = ' ';
-	switch(c = peekc()) {
-		case ',':
-		case ';':	p->Cop = getc();
-				return(0);
-	}
+  p->Cnumadr = -1;
+  p->Csep = ' ';
+  switch (c = peekc()) {
+  case ',':
+  case ';':
+    p->Cop = getc();
+    return (0);
+  }
 
-	if((r=getadrs(p,prt)) < 0) return(r);
+  if ((r = getadrs(p, prt)) < 0)
+    return (r);
 
-	if((c=peekc()) < 0) return(err(prt,"syntax"));
-	if(c == '\n') p->Cop = '\n';
-	else p->Cop = getc();
+  if ((c = peekc()) < 0)
+    return (err(prt, "syntax"));
+  if (c == '\n')
+    p->Cop = '\n';
+  else
+    p->Cop = getc();
 
-	return(0);
+  return (0);
 }
 
-
-getadrs(p,prt)
-struct Comd *p;
+getadrs(p, prt) struct Comd *p;
 int prt;
 {
-	register int r;
-	register char c;
+  register int r;
+  register char c;
 
-	if((r=getadr(p,prt)) < 0) return(r);
+  if ((r = getadr(p, prt)) < 0)
+    return (r);
 
-	switch(c=peekc()) {
-		case ';':	Dot = p->Cadr[0];
-		case ',':	getc();
-				p->Csep = c;
-				return(getadr(p,prt));
-	}
+  switch (c = peekc()) {
+  case ';':
+    Dot = p->Cadr[0];
+  case ',':
+    getc();
+    p->Csep = c;
+    return (getadr(p, prt));
+  }
 
-	return(0);
+  return (0);
 }
 
-
-getadr(p,prt)
-struct Comd *p;
+getadr(p, prt) struct Comd *p;
 int prt;
 {
-	register int r;
-	register char c,d;
+  register int r;
+  register char c, d;
 
-	r = 0;
-	while(peekc() == ' ') getc();		/* Ignore leading spaces */
-	switch(c = peekc()) {
-		case '\n':
-		case ',':
-		case ';':	return(0);
+  r = 0;
+  while (peekc() == ' ')
+    getc(); /* Ignore leading spaces */
+  switch (c = peekc()) {
+  case '\n':
+  case ',':
+  case ';':
+    return (0);
 
-		case '\'':	getc();
-				r = getmark(p,prt);
-				break;
+  case '\'':
+    getc();
+    r = getmark(p, prt);
+    break;
 
-		case '0':
-		case '1':
-		case '2':
-		case '3':
-		case '4':
-		case '5':
-		case '6':
-		case '7':
-		case '8':
-		case '9':	r = getnumb(p,prt);
-				break;
+  case '0':
+  case '1':
+  case '2':
+  case '3':
+  case '4':
+  case '5':
+  case '6':
+  case '7':
+  case '8':
+  case '9':
+    r = getnumb(p, prt);
+    break;
 
-		case '.':	getc();
-		case '+':
-		case '-':	p->Cadr[++p->Cnumadr] = Dot;
-				break;
+  case '.':
+    getc();
+  case '+':
+  case '-':
+    p->Cadr[++p->Cnumadr] = Dot;
+    break;
 
-		case '$':	getc();
-				p->Cadr[++p->Cnumadr] = Dollar;
-				break;
+  case '$':
+    getc();
+    p->Cadr[++p->Cnumadr] = Dollar;
+    break;
 
-		case '^':	getc();
-				p->Cadr[++p->Cnumadr] = Dot - 1;
-				break;
+  case '^':
+    getc();
+    p->Cadr[++p->Cnumadr] = Dot - 1;
+    break;
 
-		case '/':
-		case '?':
-		case '>':
-		case '<':	getc();
-				r = getrex(p,prt,c);
-				break;
+  case '/':
+  case '?':
+  case '>':
+  case '<':
+    getc();
+    r = getrex(p, prt, c);
+    break;
 
-		default:	return(0);
-	}
+  default:
+    return (0);
+  }
 
-	if(r == 0) r = getrel(p,prt);
-	return(r);
+  if (r == 0)
+    r = getrel(p, prt);
+  return (r);
 }
 
-
-getnumb(p,prt)
-struct Comd *p;
+getnumb(p, prt) struct Comd *p;
 int prt;
 {
-	register int i;
+  register int i;
 
-	if((i=rdnumb(prt)) < 0) return(-1);
-	p->Cadr[++p->Cnumadr] = i;
-	return(0);
+  if ((i = rdnumb(prt)) < 0)
+    return (-1);
+  p->Cadr[++p->Cnumadr] = i;
+  return (0);
 }
 
+rdnumb(prt) int prt;
+{
+  char num[20], *n;
+  int i;
 
-rdnumb(prt)
+  n = num;
+  while ((*n = peekc()) >= '0' && *n <= '9') {
+    n++;
+    getc();
+  }
+
+  *n = '\0';
+  if ((i = patoi(num)) >= 0)
+    return (i);
+  return (err(prt, "bad num"));
+}
+
+getrel(p, prt) struct Comd *p;
 int prt;
 {
-	char num[20], *n;
-	int i;
+  register int op, n;
+  register char c;
+  int j;
 
-	n = num;
-	while((*n=peekc()) >= '0' && *n <= '9') {
-		n++;
-		getc();
-	}
-
-	*n = '\0';
-	if((i=patoi(num)) >= 0) return(i);
-	return(err(prt,"bad num"));
+  n = 0;
+  op = 1;
+  while ((c = peekc()) == '+' || c == '-') {
+    if (c == '+')
+      n++;
+    else
+      n--;
+    getc();
+  }
+  j = n;
+  if (n < 0)
+    op = -1;
+  if (c == '\n')
+    p->Cadr[p->Cnumadr] += n;
+  else {
+    if ((n = rdnumb(0)) > 0 && p->Cnumadr >= 0) {
+      p->Cadr[p->Cnumadr] += op * n;
+      getrel(p, prt);
+    } else {
+      if (c == '-')
+        p->Cadr[p->Cnumadr] += j;
+      else
+        p->Cadr[p->Cnumadr] += j;
+    }
+  }
+  return (0);
 }
 
-
-getrel(p,prt)
-struct Comd *p;
+getmark(p, prt) struct Comd *p;
 int prt;
 {
-	register int op, n;
-	register char c;
-	int j;
+  register char c;
 
-	n = 0;
-	op = 1;
-	while((c=peekc())=='+' || c=='-') {
-		if(c=='+') n++;
-		else n--;
-		getc();
-	}
-	j = n;
-	if(n < 0) op = -1;
-	if(c=='\n') p->Cadr[p->Cnumadr] += n;
-	else {
-		if((n=rdnumb(0)) > 0 && p->Cnumadr >= 0) {
-			p->Cadr[p->Cnumadr] += op*n;
-			getrel(p,prt);
-		}
-		else {
-			if(c=='-') p->Cadr[p->Cnumadr] += j;
-			else p->Cadr[p->Cnumadr] += j;
-		}
-	}
-	return(0);
+  if ((c = peekc()) < 'a' || c > 'z')
+    return (err(prt, "bad mark"));
+  getc();
+
+  if (!mark[c])
+    return (err(prt, "undefined mark"));
+  p->Cadr[++p->Cnumadr] = mark[c];
+  return (0);
 }
 
-
-getmark(p,prt)
-struct Comd *p;
-int prt;
-{
-	register char c;
-
-	if((c=peekc()) < 'a' || c > 'z') return(err(prt,"bad mark"));
-	getc();
-
-	if(!mark[c]) return(err(prt,"undefined mark"));
-	p->Cadr[++p->Cnumadr] = mark[c];
-	return(0);
-}
-
-
-getrex(p,prt,c)
-struct Comd *p;
+getrex(p, prt, c) struct Comd *p;
 int prt;
 char c;
 {
-	register int down, wrap, start;
+  register int down, wrap, start;
 
-	if(peekc() == c) getc();
-	else if(getstr(prt,currex,c,0,1)) return(-1);
+  if (peekc() == c)
+    getc();
+  else if (getstr(prt, currex, c, 0, 1))
+    return (-1);
 
-	switch(c) {
-		case '/':	down = 1; wrap = 1; break;
-		case '?':	down = 0; wrap = 1; break;
-		case '>':	down = 1; wrap = 0; break;
-		case '<':	down = 0; wrap = 0; break;
-	}
+  switch (c) {
+  case '/':
+    down = 1;
+    wrap = 1;
+    break;
+  case '?':
+    down = 0;
+    wrap = 1;
+    break;
+  case '>':
+    down = 1;
+    wrap = 0;
+    break;
+  case '<':
+    down = 0;
+    wrap = 0;
+    break;
+  }
 
-	if(p->Csep == ';') start = p->Cadr[0];
-	else start = Dot;
+  if (p->Csep == ';')
+    start = p->Cadr[0];
+  else
+    start = Dot;
 
-	if((p->Cadr[++p->Cnumadr]=hunt(prt,currex,start,down,wrap,0)) < 0)
-		return(-1);
-	return(0);
+  if ((p->Cadr[++p->Cnumadr] = hunt(prt, currex, start, down, wrap, 0)) < 0)
+    return (-1);
+  return (0);
 }
 
-
-hunt(prt,rex,start,down,wrap,errsok)
-int prt, errsok;
+hunt(prt, rex, start, down, wrap, errsok) int prt, errsok;
 char rex[];
 int start, down, wrap;
 {
-	register int i, end1, incr;
-	int start1, start2;
-	char line[BFSBUF], *ptr;
+  register int i, end1, incr;
+  int start1, start2;
+  char line[BFSBUF], *ptr;
 
-	if(down) {
-		start1 = start + 1;
-		end1 = Dollar;
-		start2 = 1;
-		incr = 1;
-	}
-	else {
-		start1 = start  - 1;
-		end1 = 1;
-		start2 = Dollar;
-		incr = -1;
-	}
+  if (down) {
+    start1 = start + 1;
+    end1 = Dollar;
+    start2 = 1;
+    incr = 1;
+  } else {
+    start1 = start - 1;
+    end1 = 1;
+    start2 = Dollar;
+    incr = -1;
+  }
 
-	if((ptr = (char *)compile(rex, rebuf,&rebuf[REBUF],'\0')) == (char *) -1)
-		return(errsok?-1:err(prt,"RE syntax"));
+  if ((ptr = (char *)compile(rex, rebuf, &rebuf[REBUF], '\0')) == (char *)-1)
+    return (errsok ? -1 : err(prt, "RE syntax"));
 
-	for(i=start1; i != end1+incr; i += incr) {
-		bigread(i,line);
-		if(step(line,rebuf)) {
-			return(i);
-		}
-	}
+  for (i = start1; i != end1 + incr; i += incr) {
+    bigread(i, line);
+    if (step(line, rebuf)) {
+      return (i);
+    }
+  }
 
-	if(!wrap) return(errsok?-1:err(prt,"not found"));
+  if (!wrap)
+    return (errsok ? -1 : err(prt, "not found"));
 
-	for(i=start2; i != start1; i += incr) {
-		bigread(i,line);
-		if(step(line,rebuf)) {
-			return(i);
-		}
-	}
+  for (i = start2; i != start1; i += incr) {
+    bigread(i, line);
+    if (step(line, rebuf)) {
+      return (i);
+    }
+  }
 
-	return(errsok?-1:err(prt,"not found"));
+  return (errsok ? -1 : err(prt, "not found"));
 }
 
-
-jump(prt,label)
-int prt;
+jump(prt, label) int prt;
 char label[];
 {
-	register char c, *l;
-	char line[256], *ptr;
+  register char c, *l;
+  char line[256], *ptr;
 
-	if(infildes == 0 && tty) return(err(prt,"jump on tty"));
-	if(infildes == 100) intptr = internal;
-	else lseek(infildes,0L,0);
+  if (infildes == 0 && tty)
+    return (err(prt, "jump on tty"));
+  if (infildes == 100)
+    intptr = internal;
+  else
+    lseek(infildes, 0L, 0);
 
-	sprintf(strtmp, "^: *%s$", label);
-	if((ptr = (char *) compile(strtmp, rebuf, &rebuf[REBUF], '\0')) == (char *) -1)
-		return -1;
+  sprintf(strtmp, "^: *%s$", label);
+  if ((ptr = (char *)compile(strtmp, rebuf, &rebuf[REBUF], '\0')) == (char *)-1)
+    return -1;
 
-	for(l=line; readc(infildes,l); l++) {
-		if(*l == '\n') {
-			*l = '\0';
-			if(step(line, rebuf)) {
-				charbuf = '\n';
-				return(peeked = 0);
-			}
-			l = line - 1;
-		}
-	}
+  for (l = line; readc(infildes, l); l++) {
+    if (*l == '\n') {
+      *l = '\0';
+      if (step(line, rebuf)) {
+        charbuf = '\n';
+        return (peeked = 0);
+      }
+      l = line - 1;
+    }
+  }
 
-	return(err(prt,"label not found"));
+  return (err(prt, "label not found"));
 }
 
-
-getstr(prt,buf,brk,ignr,nonl)
-int prt, nonl;
+getstr(prt, buf, brk, ignr, nonl) int prt, nonl;
 char buf[], brk, ignr;
 {
-	register char *b, c, prevc;
+  register char *b, c, prevc;
 
-	prevc = 0;
-	for(b=buf; c=peekc(); prevc=c) {
-		if(c == '\n') {
-			if(prevc == '\\' && (!flag3)) *(b-1) = getc();
-			else if(prevc == '\\' && flag3) {
-				*b++ = getc();
-			}
-			else if(nonl) break;
-			else return(*b='\0');
-		}
-		else {
-			getc();
-			if(c == brk) {
-				if(prevc == '\\') *(b-1) = c;
-				else return(*b='\0');
-			}
-			else if(b != buf || c != ignr) *b++ = c;
-		}
-	}
-	return(err(prt,"syntax"));
+  prevc = 0;
+  for (b = buf; c = peekc(); prevc = c) {
+    if (c == '\n') {
+      if (prevc == '\\' && (!flag3))
+        *(b - 1) = getc();
+      else if (prevc == '\\' && flag3) {
+        *b++ = getc();
+      } else if (nonl)
+        break;
+      else
+        return (*b = '\0');
+    } else {
+      getc();
+      if (c == brk) {
+        if (prevc == '\\')
+          *(b - 1) = c;
+        else
+          return (*b = '\0');
+      } else if (b != buf || c != ignr)
+        *b++ = c;
+    }
+  }
+  return (err(prt, "syntax"));
 }
 
-
-regerr(c)
-int c;
+regerr(c) int c;
 {
-	if(prompt)
-		{switch(c) {
-			case 11: printf("Range endpoint too large.\n");
-				break;
-			case 16: printf("Bad number.\n");
-				break;
-			case 25: printf("\digit out of range.\n");
-				break;
-			case 36: printf("Illegal or missing delimiter.\n");
-				break;
-			case 41: printf("No remembered search string.\n");
-				break;
-			case 42: printf("\(\) imbalance.\n");
-				break;
-			case 43: printf("Too many \(.\n");
-				break;
-			case 44: printf("More than 2 numbers given in \{ \}.\n");
-				break;
-			case 45: printf("}expected after \.\n");
-				break;
-			case 46: printf("First number excceds second in \{ \}.\n");
-				break;
-			case 49: printf("[] imbalance.\n");
-				break;
-			case 50: printf("Regular expression overflow.\n");
-				break;
-			default: printf("RE error.\n");
-				break;
-		}
-	}
-	if(!prompt)printf("?\n");
-	return(-1);
+  if (prompt) {
+    switch (c) {
+    case 11:
+      printf("Range endpoint too large.\n");
+      break;
+    case 16:
+      printf("Bad number.\n");
+      break;
+    case 25:
+      printf("\digit out of range.\n");
+      break;
+    case 36:
+      printf("Illegal or missing delimiter.\n");
+      break;
+    case 41:
+      printf("No remembered search string.\n");
+      break;
+    case 42:
+      printf("\(\) imbalance.\n");
+      break;
+    case 43:
+      printf("Too many \(.\n");
+      break;
+    case 44:
+      printf("More than 2 numbers given in \{ \}.\n");
+      break;
+    case 45:
+      printf("}expected after \.\n");
+      break;
+    case 46:
+      printf("First number excceds second in \{ \}.\n");
+      break;
+    case 49:
+      printf("[] imbalance.\n");
+      break;
+    case 50:
+      printf("Regular expression overflow.\n");
+      break;
+    default:
+      printf("RE error.\n");
+      break;
+    }
+  }
+  if (!prompt)
+    printf("?\n");
+  return (-1);
 }
 
-err(prt,msg)
-int prt;
+err(prt, msg) int prt;
 char msg[];
 {
-	if(prt) (prompt? printf("%s\n",msg): printf("?\n"));
-	if(infildes != 0) {
-		infildes = pop(fstack);
-		charbuf = '\n';
-		peeked = 0;
-		flag3 = 0;
-		flag2 = 0;
-		flag = 0;
-	}
-	return(-1);
+  if (prt)
+    (prompt ? printf("%s\n", msg) : printf("?\n"));
+  if (infildes != 0) {
+    infildes = pop(fstack);
+    charbuf = '\n';
+    peeked = 0;
+    flag3 = 0;
+    flag2 = 0;
+    flag = 0;
+  }
+  return (-1);
 }
 
-
-getc()
-{
-	if(!peeked) {
-		while((!(infildes == oldfd && flag)) && (!flag1) && (!readc(infildes,&charbuf))) {
-			if(infildes == 100 && (!flag)) flag1 = 1;
-			if((infildes=pop(fstack)) == -1) quit();
-			if((!flag1) && infildes == 0 && flag3 && prompt) printf("*");
-		}
-		if(infildes == oldfd && flag) flag2 = 0;
-		flag1 = 0;
-	}
-	else peeked = 0;
-	return(charbuf);
+getc() {
+  if (!peeked) {
+    while ((!(infildes == oldfd && flag)) && (!flag1) &&
+           (!readc(infildes, &charbuf))) {
+      if (infildes == 100 && (!flag))
+        flag1 = 1;
+      if ((infildes = pop(fstack)) == -1)
+        quit();
+      if ((!flag1) && infildes == 0 && flag3 && prompt)
+        printf("*");
+    }
+    if (infildes == oldfd && flag)
+      flag2 = 0;
+    flag1 = 0;
+  } else
+    peeked = 0;
+  return (charbuf);
 }
 
-
-readc(f,c)
-int f;
+readc(f, c) int f;
 char *c;
 {
-	if(f == 100) {
-		if(!(*c = *intptr++)) {
-			intptr--;
-			charbuf = '\n';
-			return(0);
-		}
-	}
-	else if(read(f,c,1) != 1) {
-		close(f);
-		charbuf = '\n';
-		return(0);
-	}
-	return(1);
+  if (f == 100) {
+    if (!(*c = *intptr++)) {
+      intptr--;
+      charbuf = '\n';
+      return (0);
+    }
+  } else if (read(f, c, 1) != 1) {
+    close(f);
+    charbuf = '\n';
+    return (0);
+  }
+  return (1);
 }
 
-
-percent(line)
-char line[256];
+percent(line) char line[256];
 {
-	register char *lp, *per, *var;
-	char *front, c[2], *olp, p[2], fr[256], *copy();
-	int i,j;
+  register char *lp, *per, *var;
+  char *front, c[2], *olp, p[2], fr[256], *copy();
+  int i, j;
 
-	per = p;
-	var = c;
-	front = fr;
-	j = 0;
-	circf = circf1;		/* Restore circf for step()  (regexp.h) */
-	while(!j) {
-		j = 1;
-		olp = line;
-		intptr = internal;
-		while(step(olp,perbuf)) {
-			while(loc1 < loc2) *front++ = *loc1++;
-			*(--front) = '\0';
-			front = fr;
-			*per = '%';
-			*var = *loc2;
-			if((i = bsize(front)) >= 2 && fr[i-2] == '\\') {
-				cat(front,"");
-				--intptr;
-				cat(per,"");
-			}
-			else {
-				if(!(*var >= '0' && *var <= '9')) return(err(1,"usage: %digit"));
-				cat(front,"");
-				cat(varray[*var-'0'],"");
-				j =0;
-				loc2++;	/* Compensate for removing --lp above */
-			}
-			olp = loc2;
-		}
-		cat(olp,"");
-		*intptr = '\0';
-		if(!j) {
-			intptr = internal;
-			lp = line;
-			copy(intptr,lp);
-		}
-	}
+  per = p;
+  var = c;
+  front = fr;
+  j = 0;
+  circf = circf1; /* Restore circf for step()  (regexp.h) */
+  while (!j) {
+    j = 1;
+    olp = line;
+    intptr = internal;
+    while (step(olp, perbuf)) {
+      while (loc1 < loc2)
+        *front++ = *loc1++;
+      *(--front) = '\0';
+      front = fr;
+      *per = '%';
+      *var = *loc2;
+      if ((i = bsize(front)) >= 2 && fr[i - 2] == '\\') {
+        cat(front, "");
+        --intptr;
+        cat(per, "");
+      } else {
+        if (!(*var >= '0' && *var <= '9'))
+          return (err(1, "usage: %digit"));
+        cat(front, "");
+        cat(varray[*var - '0'], "");
+        j = 0;
+        loc2++; /* Compensate for removing --lp above */
+      }
+      olp = loc2;
+    }
+    cat(olp, "");
+    *intptr = '\0';
+    if (!j) {
+      intptr = internal;
+      lp = line;
+      copy(intptr, lp);
+    }
+  }
 }
 
-cat(arg1,arg2)
-char arg1[],arg2[];
+cat(arg1, arg2) char arg1[], arg2[];
 {
-	register char *arg;
+  register char *arg;
 
-	arg = arg1;
-	while(*arg) *intptr++ = *arg++;
-	if(*arg2) {
-		arg = arg2;
-		while(*arg) *intptr++ = *arg++;
-	}
+  arg = arg1;
+  while (*arg)
+    *intptr++ = *arg++;
+  if (*arg2) {
+    arg = arg2;
+    while (*arg)
+      *intptr++ = *arg++;
+  }
 }
 
-
-newfile(prt,f)
-int prt;
+newfile(prt, f) int prt;
 char f[];
 {
-	register int fd;
+  register int fd;
 
-	if(!*f) {
-		if(flag != 0) {
-			oldfd = infildes;
-			intptr = comdlist;
-		}
-		else intptr = internal;
-		fd = 100;
-	}
-	else if((fd=open(f,0)) < 0) {
-		sprintf(strtmp, "bfs: cannot open %s", f);
-		return err(prt, strtmp);
-	}
+  if (!*f) {
+    if (flag != 0) {
+      oldfd = infildes;
+      intptr = comdlist;
+    } else
+      intptr = internal;
+    fd = 100;
+  } else if ((fd = open(f, 0)) < 0) {
+    sprintf(strtmp, "bfs: cannot open %s", f);
+    return err(prt, strtmp);
+  }
 
-	push(fstack,infildes);
-	if(flag4) oldfd = fd;
-	infildes = fd;
-	return(peeked=0);
+  push(fstack, infildes);
+  if (flag4)
+    oldfd = fd;
+  infildes = fd;
+  return (peeked = 0);
 }
 
-
-push(s,d)
-int s[], d;
+push(s, d) int s[], d;
 {
-	s[++s[0]] = d;
+  s[++s[0]] = d;
 }
 
-
-pop(s)
-int s[];
+pop(s) int s[];
 {
-	return(s[s[0]--]);
+  return (s[s[0]--]);
 }
 
+peekc() {
+  register char c;
 
-peekc()
+  c = getc();
+  peeked = 1;
+
+  return (c);
+}
+
+eat() {
+  if (charbuf != '\n')
+    while (getc() != '\n')
+      ;
+  peeked = 0;
+}
+
+more() {
+  if (getc() != '\n')
+    return (err(1, "syntax"));
+  return (0);
+}
+
+quit() { exit(); }
+
+out(ln) char *ln;
 {
-	register char c;
+  register char *rp, *wp, prev;
+  char *untab();
+  int lim;
 
-	c = getc();
-	peeked = 1;
+  if (crunch > 0) {
 
-	return(c);
+    ln = untab(ln);
+    rp = wp = ln - 1;
+    prev = ' ';
+
+    while (*++rp) {
+      if (prev != ' ' || *rp != ' ')
+        *++wp = *rp;
+      prev = *rp;
+    }
+    *++wp = '\n';
+    lim = wp - ln;
+    *++wp = '\0';
+
+    if (*ln == '\n')
+      return;
+  } else
+    ln[lim = bsize(ln) - 1] = '\n';
+
+  if (lim > trunc)
+    ln[lim = trunc] = '\n';
+  outcnt += write(outfildes, ln, lim + 1);
 }
 
-
-eat()
-{
-	if(charbuf != '\n') while(getc() != '\n');
-	peeked = 0;
-}
-
-
-more()
-{
-	if(getc() != '\n') return(err(1,"syntax"));
-	return(0);
-}
-
-
-quit()
-{
-	exit();
-}
-
-
-out(ln)
-char *ln;
-{
-	register char *rp, *wp, prev;
-	char *untab();
-	int lim;
-
-	if(crunch > 0) {
-
-		ln = untab(ln);
-		rp = wp = ln - 1;
-		prev = ' ';
-
-		while(*++rp) {
-			if(prev != ' ' || *rp != ' ') *++wp = *rp;
-			prev = *rp;
-		}
-		*++wp = '\n';
-		lim = wp - ln;
-		*++wp = '\0';
-
-		if(*ln == '\n') return;
-	}
-	else ln[lim=bsize(ln)-1] = '\n';
-
-	if(lim > trunc) ln[lim=trunc] = '\n';
-	outcnt += write(outfildes,ln,lim+1);
-}
-
-
-
-
-char *
-untab(l)
+char *untab(l)
 char l[];
 {
-	static char line[BFSBUF];
-	register char *q, *s;
+  static char line[BFSBUF];
+  register char *q, *s;
 
-	s = l;
-	q = line;
-	do {
-		if(*s == '\t')
-			do *q++ = ' '; while((q-line)%8);
-		else *q++ = *s;
-	} while(*s++);
-	return(line);
+  s = l;
+  q = line;
+  do {
+    if (*s == '\t')
+      do
+        *q++ = ' ';
+      while ((q - line) % 8);
+    else
+      *q++ = *s;
+  } while (*s++);
+  return (line);
 }
 /*
-	Function to convert ascii string to integer.  Converts
-	positive numbers only.  Returns -1 if non-numeric
-	character encountered.
+        Function to convert ascii string to integer.  Converts
+        positive numbers only.  Returns -1 if non-numeric
+        character encountered.
 */
 
-patoi(b)
-char *b;
+patoi(b) char *b;
 {
-	register int i;
-	register char *a;
+  register int i;
+  register char *a;
 
-	a = b;
-	i = 0;
-	while(*a >= '0' && *a <= '9') i = 10 * i + *a++ - '0';
+  a = b;
+  i = 0;
+  while (*a >= '0' && *a <= '9')
+    i = 10 * i + *a++ - '0';
 
-	if(*a) return(-1);
-	return(i);
+  if (*a)
+    return (-1);
+  return (i);
 }
 /*
-	Returns size (counting null byte) of arg string.
+        Returns size (counting null byte) of arg string.
 */
 
-bsize(s)
-char s[];
+bsize(s) char s[];
 {
-	register int i;
+  register int i;
 
-	i = 0;
-	while(s[i++]);
-	return(i);
+  i = 0;
+  while (s[i++])
+    ;
+  return (i);
 }
 /*
-	Copy first string to second; no overflow checking.
-	Returns pointer to null in new string.
+        Copy first string to second; no overflow checking.
+        Returns pointer to null in new string.
 */
 
-char *
-copy(a,b)
+char *copy(a, b)
 register char *a, *b;
 {
-	while(*b++ = *a++);
-	return(--b);
+  while (*b++ = *a++)
+    ;
+  return (--b);
 }
 /*
-	Compares 2 strings.  Returns 1 if equal, 0 if not.
+        Compares 2 strings.  Returns 1 if equal, 0 if not.
 */
 
-equal(a,b)
-char *a, *b;
+equal(a, b) char *a, *b;
 {
-	register char *x, *y;
+  register char *x, *y;
 
-	x = a;
-	y = b;
-	while (*x == *y++) if (*x++ == 0) return(1);
-	return(0);
+  x = a;
+  y = b;
+  while (*x == *y++)
+    if (*x++ == 0)
+      return (1);
+  return (0);
 }

--- a/src/cmd/bufstat.c
+++ b/src/cmd/bufstat.c
@@ -4,33 +4,37 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file bufstat.c
+ * @brief Buffer cache status.
+ */
 
 static char Sccsid[] = "@(#)bufstat.c	3.0	4/21/86";
+#include <a.out.h>
 #include <stdio.h>
+#include <sys/dir.h>
 #include <sys/param.h>
 #include <sys/stat.h>
-#include <sys/dir.h>
-#include <a.out.h>
-#define	UCB_BHASH	/* for buf.h */
-#define	MAPMOUNT	/* for buf.h */
+#define UCB_BHASH /* for buf.h */
+#define MAPMOUNT  /* for buf.h */
 #include <sys/buf.h>
 
 FILE *dirf;
 struct nlist nli[] = {
-	"_buf", 0, 0,		/* 0 */
-	"_io_info", 0, 0,	/* 1 */
-	"_nbuf", 0, 0,		/* 2 */
-	0, 0, 0,
- };
+    "_buf",     0, 0, /* 0 */
+    "_io_info", 0, 0, /* 1 */
+    "_nbuf",    0, 0, /* 2 */
+    0,          0, 0,
+};
 
 struct iostat {
-	int	nbuf;
-	long	nread;
-	long	nreada;
-	long	ncache;
-	long	nwrite;
-	long	bufcount[1];
-}*io_info;
+  int nbuf;
+  long nread;
+  long nreada;
+  long ncache;
+  long nwrite;
+  long bufcount[1];
+} *io_info;
 int infosize;
 
 struct buf **bhdr;
@@ -38,228 +42,205 @@ struct direct dir;
 struct stat sts;
 
 struct {
-	dev_t bdev;
-	char bname[DIRSIZ];
-}btype[257];
+  dev_t bdev;
+  char bname[DIRSIZ];
+} btype[257];
 
 int mem, interval;
 long addr;
 char *infile = "/unix";
 char *coref = "/dev/mem";
-char *usage = "bufstat: usage  bufstat [ifn] [interval] [corefile] [namelist]\n";
-char *flgs[14] = {
-	"|DN",
-	"|ERR",
-	"|BSY",
-	"|PHY",
-	"|MAP",
-	"|WNT",
-	"|AGE",
-	"|ASY",
-	"|DLW",
-	"|TAP",
-	"|PBY",
-	"|PAC",
-	"|MNT",
-	0
-};
+char *usage =
+    "bufstat: usage  bufstat [ifn] [interval] [corefile] [namelist]\n";
+char *flgs[14] = {"|DN",  "|ERR", "|BSY", "|PHY", "|MAP", "|WNT", "|AGE",
+                  "|ASY", "|DLW", "|TAP", "|PBY", "|PAC", "|MNT", 0};
 
-char	flgstr[40];
+char flgstr[40];
 char devnam[64];
-int	wflag = 0;
+int wflag = 0;
 
-main(argc, argp)
-int argc;
+main(argc, argp) int argc;
 char *argp[];
 {
-	int cnt, cnt1;
-	char *ap;
+  int cnt, cnt1;
+  char *ap;
 
-	argp++;
-	for(ap = *argp++; ap && *ap; ap++)
-		switch(*ap){
-			case 'f':
-				coref = *argp++;
-				break;
-			case 'i':
-				interval = atoi(*argp++);
-				break;
-			case 'n':
-				infile = *argp++;
-				break;
-			case '-':
-				break;
-			case 'w':
-				++wflag;
-				break;
-			default:
-				fprintf(stderr, "%s", usage);
-				exit(1);
-				break;
-		}
-	initmem();
-	while(1){
-		lbuf();
-		bufsts();
-		if(interval)
-			sleep(interval);
-		else
-			exit(0);
-	}
+  argp++;
+  for (ap = *argp++; ap && *ap; ap++)
+    switch (*ap) {
+    case 'f':
+      coref = *argp++;
+      break;
+    case 'i':
+      interval = atoi(*argp++);
+      break;
+    case 'n':
+      infile = *argp++;
+      break;
+    case '-':
+      break;
+    case 'w':
+      ++wflag;
+      break;
+    default:
+      fprintf(stderr, "%s", usage);
+      exit(1);
+      break;
+    }
+  initmem();
+  while (1) {
+    lbuf();
+    bufsts();
+    if (interval)
+      sleep(interval);
+    else
+      exit(0);
+  }
 }
 
-lbuf()
-{
-	int cnt;
+lbuf() {
+  int cnt;
 
-	lseek(mem, (long)nli[1].n_value, 0);
-	read(mem, io_info, infosize);
-	lseek(mem, (long)nli[0].n_value, 0);
-	for(cnt = 0; cnt < io_info->nbuf; cnt++)
-		read(mem, bhdr[cnt], sizeof(struct buf));
+  lseek(mem, (long)nli[1].n_value, 0);
+  read(mem, io_info, infosize);
+  lseek(mem, (long)nli[0].n_value, 0);
+  for (cnt = 0; cnt < io_info->nbuf; cnt++)
+    read(mem, bhdr[cnt], sizeof(struct buf));
 }
 
-bufsts()
-{
-	int cnt, fcnt, devpnt;
-	struct buf *bufoff;
+bufsts() {
+  int cnt, fcnt, devpnt;
+  struct buf *bufoff;
 
-	printf("\nBuffer Pool Status\n\n");
-	if (wflag)
-		printf("        ");
-	printf("Buffer    I/O ops  Byte    Logic\n");
-	if (wflag)
-		printf("Bufaddr ");
-	printf("Address   per buf  count   blkno  err   ");
-	printf("device         ");
-	if (wflag)
-		printf("b_forw  b_back  av_forw av_back ");
-	printf("flags\n");
-	printf("----------------------------------------");
-	printf("---------------");
-	if (wflag)
-		printf("---------------------------------------");
-	printf("------------------------\n");
-	bufoff = (struct buf *)nli[0].n_value;
-	for(cnt = 0; cnt < io_info->nbuf; cnt++){
-		if (wflag)
-			printf("0%-6o ", bufoff++);
-		addr = (long)bhdr[cnt]->b_xmem << 16;
-		addr += (unsigned)bhdr[cnt]->b_un.b_addr;
-		printf("0%-8lo ", addr);
-		printf("%-8ld ", io_info->bufcount[cnt]);
-		printf("0%-6o ", bhdr[cnt]->b_bcount);
-		addr = bhdr[cnt]->b_blkno;
-		printf("0%-6D ", addr);
-		printf("%-4o ", (unsigned)bhdr[cnt]->b_error);
-		if((devpnt = find(cnt)) >= 0)
-			printf("%-14s ", btype[devpnt].bname);
-		else{
-			if(bhdr[cnt]->b_dev < 0)
-				printf("%-14s ", "system");
-			else
-				printf("%-2d %-11d ", major(bhdr[cnt]->b_dev),
-				   minor(bhdr[cnt]->b_dev));
-		}
-		if((bhdr[cnt]->b_flags&B_READ) == 0)
-			strcpy(flgstr, "WRT");
-		else
-			strcpy(flgstr, "RD");
-		for(fcnt = 0; flgs[fcnt]; fcnt++){
-			if(bhdr[cnt]->b_flags&(2<<fcnt))
-				strcat(flgstr, flgs[fcnt]);
-		}
-		flgstr[25] = 0;
-		if (wflag) {
-			printf("0%-6o 0%-6o 0%-6o 0%-6o ",
-				bhdr[cnt]->b_forw,
-				bhdr[cnt]->b_back,
-				bhdr[cnt]->av_forw,
-				bhdr[cnt]->av_back);
-		}
-		printf("%-25s\n", flgstr);
-			
-	}
+  printf("\nBuffer Pool Status\n\n");
+  if (wflag)
+    printf("        ");
+  printf("Buffer    I/O ops  Byte    Logic\n");
+  if (wflag)
+    printf("Bufaddr ");
+  printf("Address   per buf  count   blkno  err   ");
+  printf("device         ");
+  if (wflag)
+    printf("b_forw  b_back  av_forw av_back ");
+  printf("flags\n");
+  printf("----------------------------------------");
+  printf("---------------");
+  if (wflag)
+    printf("---------------------------------------");
+  printf("------------------------\n");
+  bufoff = (struct buf *)nli[0].n_value;
+  for (cnt = 0; cnt < io_info->nbuf; cnt++) {
+    if (wflag)
+      printf("0%-6o ", bufoff++);
+    addr = (long)bhdr[cnt]->b_xmem << 16;
+    addr += (unsigned)bhdr[cnt]->b_un.b_addr;
+    printf("0%-8lo ", addr);
+    printf("%-8ld ", io_info->bufcount[cnt]);
+    printf("0%-6o ", bhdr[cnt]->b_bcount);
+    addr = bhdr[cnt]->b_blkno;
+    printf("0%-6D ", addr);
+    printf("%-4o ", (unsigned)bhdr[cnt]->b_error);
+    if ((devpnt = find(cnt)) >= 0)
+      printf("%-14s ", btype[devpnt].bname);
+    else {
+      if (bhdr[cnt]->b_dev < 0)
+        printf("%-14s ", "system");
+      else
+        printf("%-2d %-11d ", major(bhdr[cnt]->b_dev), minor(bhdr[cnt]->b_dev));
+    }
+    if ((bhdr[cnt]->b_flags & B_READ) == 0)
+      strcpy(flgstr, "WRT");
+    else
+      strcpy(flgstr, "RD");
+    for (fcnt = 0; flgs[fcnt]; fcnt++) {
+      if (bhdr[cnt]->b_flags & (2 << fcnt))
+        strcat(flgstr, flgs[fcnt]);
+    }
+    flgstr[25] = 0;
+    if (wflag) {
+      printf("0%-6o 0%-6o 0%-6o 0%-6o ", bhdr[cnt]->b_forw, bhdr[cnt]->b_back,
+             bhdr[cnt]->av_forw, bhdr[cnt]->av_back);
+    }
+    printf("%-25s\n", flgstr);
+  }
 }
 
-find(pnt)
-{
-	int cnt;
+find(pnt) {
+  int cnt;
 
-	for(cnt = 0; btype[cnt].bdev >= 0; cnt++){
-		if(strcmp("swap", btype[cnt].bname) == 0)
-			continue;
-		if(btype[cnt].bdev == bhdr[pnt]->b_dev)
-			return(cnt);
-	}
-	return(-1);
+  for (cnt = 0; btype[cnt].bdev >= 0; cnt++) {
+    if (strcmp("swap", btype[cnt].bname) == 0)
+      continue;
+    if (btype[cnt].bdev == bhdr[pnt]->b_dev)
+      return (cnt);
+  }
+  return (-1);
 }
 
-initmem()
-{
-	int cnt;
+initmem() {
+  int cnt;
 
-	nlist(infile, nli);
-	for(cnt = 0; nli[cnt].n_name[0]; cnt++){
-		if(nli[cnt].n_value == 0){
-	printf("bufstat : FATAL : nlist failed for entry %s\r", nli[cnt].n_name);
-			exit(0);
-		}
-	}
-	if((mem = open(coref, 0)) <= 0){
-		printf("bufstat: FATAL : could not open %s\r", coref);
-		exit(0);
-	}
-	lseek(mem, (long)nli[2].n_value, 0);
-	read(mem, &cnt, sizeof(cnt));		/* get nbuf... */
-	infosize = sizeof(*io_info)+(cnt-1)*sizeof(long);
-	io_info = malloc(infosize);
-	if (io_info == NULL) {
-		printf("bufstat : FATAL : io_info malloc failed\n");
-		exit(1);
-	}
-	lseek(mem, (long)nli[1].n_value, 0);
-	read(mem, io_info, infosize);	/* get nbuf, etc */
+  nlist(infile, nli);
+  for (cnt = 0; nli[cnt].n_name[0]; cnt++) {
+    if (nli[cnt].n_value == 0) {
+      printf("bufstat : FATAL : nlist failed for entry %s\r", nli[cnt].n_name);
+      exit(0);
+    }
+  }
+  if ((mem = open(coref, 0)) <= 0) {
+    printf("bufstat: FATAL : could not open %s\r", coref);
+    exit(0);
+  }
+  lseek(mem, (long)nli[2].n_value, 0);
+  read(mem, &cnt, sizeof(cnt)); /* get nbuf... */
+  infosize = sizeof(*io_info) + (cnt - 1) * sizeof(long);
+  io_info = malloc(infosize);
+  if (io_info == NULL) {
+    printf("bufstat : FATAL : io_info malloc failed\n");
+    exit(1);
+  }
+  lseek(mem, (long)nli[1].n_value, 0);
+  read(mem, io_info, infosize); /* get nbuf, etc */
 
-	bhdr = (struct buf **)malloc((io_info->nbuf+1) * sizeof(*bhdr));
-	if (bhdr == NULL) {
-		printf("bufstat : FATAL : bhdr malloc failed\n");
-		exit(1);
-	}
-	/* allocate buffer header space */
-	for(cnt = 0; cnt < io_info->nbuf; cnt++){
-		if((bhdr[cnt] = malloc(sizeof(struct buf))) == 0){
-	printf("bufstat : FATAL : buf malloc failed for entry %d\n", cnt);
-			exit(1);
-		}
-	}
+  bhdr = (struct buf **)malloc((io_info->nbuf + 1) * sizeof(*bhdr));
+  if (bhdr == NULL) {
+    printf("bufstat : FATAL : bhdr malloc failed\n");
+    exit(1);
+  }
+  /* allocate buffer header space */
+  for (cnt = 0; cnt < io_info->nbuf; cnt++) {
+    if ((bhdr[cnt] = malloc(sizeof(struct buf))) == 0) {
+      printf("bufstat : FATAL : buf malloc failed for entry %d\n", cnt);
+      exit(1);
+    }
+  }
 
-	/* get block device info */
-	for(cnt=0; cnt<257; cnt++)
-		btype[cnt].bdev = -1;
-	if((dirf = fopen("/dev", "r")) != NULL){
-		strcpy(&devnam, "/dev/");
-		for(cnt = 0;;){
-			if(cnt >= 256){
-			printf("bufstat : WARNING : Too many block devices\n");
-				break;
-			}
-			if(fread((char *)&dir, sizeof(dir), 1, dirf) != 1)
-				break;
-			if(dir.d_ino == 0 || strcmp(dir.d_name, ".") == 0
-			  || strcmp(dir.d_name, "..") == 0)
-				continue;
-			strcpy(&devnam[5], dir.d_name);
-			if(stat(&devnam, &sts)){
-				continue;
-			}
-			if((sts.st_mode&S_IFMT) != S_IFBLK)
-				continue;
-			btype[cnt].bdev = sts.st_rdev;
-			strcpy(btype[cnt++].bname, dir.d_name);
-		}
-	}else{
-		printf("bufstat : WARNING : Could not open /dev\n");
-	}
-	fclose(dirf);
+  /* get block device info */
+  for (cnt = 0; cnt < 257; cnt++)
+    btype[cnt].bdev = -1;
+  if ((dirf = fopen("/dev", "r")) != NULL) {
+    strcpy(&devnam, "/dev/");
+    for (cnt = 0;;) {
+      if (cnt >= 256) {
+        printf("bufstat : WARNING : Too many block devices\n");
+        break;
+      }
+      if (fread((char *)&dir, sizeof(dir), 1, dirf) != 1)
+        break;
+      if (dir.d_ino == 0 || strcmp(dir.d_name, ".") == 0 ||
+          strcmp(dir.d_name, "..") == 0)
+        continue;
+      strcpy(&devnam[5], dir.d_name);
+      if (stat(&devnam, &sts)) {
+        continue;
+      }
+      if ((sts.st_mode & S_IFMT) != S_IFBLK)
+        continue;
+      btype[cnt].bdev = sts.st_rdev;
+      strcpy(btype[cnt++].bname, dir.d_name);
+    }
+  } else {
+    printf("bufstat : WARNING : Could not open /dev\n");
+  }
+  fclose(dirf);
 }

--- a/src/cmd/cal.c
+++ b/src/cmd/cal.c
@@ -4,173 +4,172 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file cal.c
+ * @brief Print calendar.
+ */
 
 static char Sccsid[] = "@(#)cal.c 3.0 4/21/86";
-char	dayw[] = {
-	" S  M Tu  W Th  F  S"
+char dayw[] = {" S  M Tu  W Th  F  S"};
+char *smon[] = {
+    "January", "February", "March",     "April",   "May",      "June",
+    "July",    "August",   "September", "October", "November", "December",
 };
-char	*smon[]= {
-	"January", "February", "March", "April",
-	"May", "June", "July", "August",
-	"September", "October", "November", "December",
-};
-char	string[432];
-main(argc, argv)
-char *argv[];
-{
-	register y, i, j;
-	int m;
-
-	if(argc < 2) {
-		printf("usage: cal [month] year\n");
-		exit(0);
-	}
-	if(argc == 2)
-		goto xlong;
-
-/*
- *	print out just month
+char string[432];
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
  */
+int main(int argc, char **argv) {
+  register y, i, j;
+  int m;
 
-	m = number(argv[1]);
-	if(m<1 || m>12)
-		goto badarg;
-	y = number(argv[2]);
-	if(y<1 || y>9999)
-		goto badarg;
-	printf("   %s %u\n", smon[m-1], y);
-	printf("%s\n", dayw);
-	cal(m, y, string, 24);
-	for(i=0; i<6*24; i+=24)
-		pstr(string+i, 24);
-	exit(0);
+  if (argc < 2) {
+    printf("usage: cal [month] year\n");
+    exit(0);
+  }
+  if (argc == 2)
+    goto xlong;
 
-/*
- *	print out complete year
- */
+  /*
+   *	print out just month
+   */
+
+  m = number(argv[1]);
+  if (m < 1 || m > 12)
+    goto badarg;
+  y = number(argv[2]);
+  if (y < 1 || y > 9999)
+    goto badarg;
+  printf("   %s %u\n", smon[m - 1], y);
+  printf("%s\n", dayw);
+  cal(m, y, string, 24);
+  for (i = 0; i < 6 * 24; i += 24)
+    pstr(string + i, 24);
+  exit(0);
+
+  /*
+   *	print out complete year
+   */
 
 xlong:
-	y = number(argv[1]);
-	if(y<1 || y>9999)
-		goto badarg;
-	printf("\n\n\n");
-	printf("				%u\n", y);
-	printf("\n");
-	for(i=0; i<12; i+=3) {
-		for(j=0; j<6*72; j++)
-			string[j] = '\0';
-		printf("	 %.3s", smon[i]);
-		printf("			%.3s", smon[i+1]);
-		printf("		       %.3s\n", smon[i+2]);
-		printf("%s   %s   %s\n", dayw, dayw, dayw);
-		cal(i+1, y, string, 72);
-		cal(i+2, y, string+23, 72);
-		cal(i+3, y, string+46, 72);
-		for(j=0; j<6*72; j+=72)
-			pstr(string+j, 72);
-	}
-	printf("\n\n\n");
-	exit(0);
+  y = number(argv[1]);
+  if (y < 1 || y > 9999)
+    goto badarg;
+  printf("\n\n\n");
+  printf("				%u\n", y);
+  printf("\n");
+  for (i = 0; i < 12; i += 3) {
+    for (j = 0; j < 6 * 72; j++)
+      string[j] = '\0';
+    printf("	 %.3s", smon[i]);
+    printf("			%.3s", smon[i + 1]);
+    printf("		       %.3s\n", smon[i + 2]);
+    printf("%s   %s   %s\n", dayw, dayw, dayw);
+    cal(i + 1, y, string, 72);
+    cal(i + 2, y, string + 23, 72);
+    cal(i + 3, y, string + 46, 72);
+    for (j = 0; j < 6 * 72; j += 72)
+      pstr(string + j, 72);
+  }
+  printf("\n\n\n");
+  exit(0);
 
 badarg:
-	printf("Bad argument\n");
+  printf("Bad argument\n");
 }
 
-number(str)
-char *str;
+number(str) char *str;
 {
-	register n, c;
-	register char *s;
+  register n, c;
+  register char *s;
 
-	n = 0;
-	s = str;
-	while(c = *s++) {
-		if(c<'0' || c>'9')
-			return(0);
-		n = n*10 + c-'0';
-	}
-	return(n);
+  n = 0;
+  s = str;
+  while (c = *s++) {
+    if (c < '0' || c > '9')
+      return (0);
+    n = n * 10 + c - '0';
+  }
+  return (n);
 }
 
-pstr(str, n)
-char *str;
+pstr(str, n) char *str;
 {
-	register i;
-	register char *s;
+  register i;
+  register char *s;
 
-	s = str;
-	i = n;
-	while(i--)
-		if(*s++ == '\0')
-			s[-1] = ' ';
-	i = n+1;
-	while(i--)
-		if(*--s != ' ')
-			break;
-	s[1] = '\0';
-	printf("%s\n", str);
+  s = str;
+  i = n;
+  while (i--)
+    if (*s++ == '\0')
+      s[-1] = ' ';
+  i = n + 1;
+  while (i--)
+    if (*--s != ' ')
+      break;
+  s[1] = '\0';
+  printf("%s\n", str);
 }
 
-char	mon[] = {
-	0,
-	31, 29, 31, 30,
-	31, 30, 31, 31,
-	30, 31, 30, 31,
+char mon[] = {
+    0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
 };
 
-cal(m, y, p, w)
-char *p;
+cal(m, y, p, w) char *p;
 {
-	register d, i;
-	register char *s;
+  register d, i;
+  register char *s;
 
-	s = p;
-	d = jan1(y);
-	mon[2] = 29;
-	mon[9] = 30;
+  s = p;
+  d = jan1(y);
+  mon[2] = 29;
+  mon[9] = 30;
 
-	switch((jan1(y+1)+7-d)%7) {
+  switch ((jan1(y + 1) + 7 - d) % 7) {
 
-	/*
-	 *	non-leap year
-	 */
-	case 1:
-		mon[2] = 28;
-		break;
+  /*
+   *	non-leap year
+   */
+  case 1:
+    mon[2] = 28;
+    break;
 
-	/*
-	 *	1752
-	 */
-	default:
-		mon[9] = 19;
-		break;
+  /*
+   *	1752
+   */
+  default:
+    mon[9] = 19;
+    break;
 
-	/*
-	 *	leap year
-	 */
-	case 2:
-		;
-	}
-	for(i=1; i<m; i++)
-		d += mon[i];
-	d %= 7;
-	s += 3*d;
-	for(i=1; i<=mon[m]; i++) {
-		if(i==3 && mon[m]==19) {
-			i += 11;
-			mon[m] += 11;
-		}
-		if(i > 9)
-			*s = i/10+'0';
-		s++;
-		*s++ = i%10+'0';
-		s++;
-		if(++d == 7) {
-			d = 0;
-			s = p+w;
-			p = s;
-		}
-	}
+  /*
+   *	leap year
+   */
+  case 2:;
+  }
+  for (i = 1; i < m; i++)
+    d += mon[i];
+  d %= 7;
+  s += 3 * d;
+  for (i = 1; i <= mon[m]; i++) {
+    if (i == 3 && mon[m] == 19) {
+      i += 11;
+      mon[m] += 11;
+    }
+    if (i > 9)
+      *s = i / 10 + '0';
+    s++;
+    *s++ = i % 10 + '0';
+    s++;
+    if (++d == 7) {
+      d = 0;
+      s = p + w;
+      p = s;
+    }
+  }
 }
 
 /*
@@ -178,35 +177,34 @@ char *p;
  *	of jan 1 of given year
  */
 
-jan1(yr)
-{
-	register y, d;
+jan1(yr) {
+  register y, d;
 
-/*
- *	normal gregorian calendar
- *	one extra day per four years
- */
+  /*
+   *	normal gregorian calendar
+   *	one extra day per four years
+   */
 
-	y = yr;
-	d = 4+y+(y+3)/4;
+  y = yr;
+  d = 4 + y + (y + 3) / 4;
 
-/*
- *	julian calendar
- *	regular gregorian
- *	less three days per 400
- */
+  /*
+   *	julian calendar
+   *	regular gregorian
+   *	less three days per 400
+   */
 
-	if(y > 1800) {
-		d -= (y-1701)/100;
-		d += (y-1601)/400;
-	}
+  if (y > 1800) {
+    d -= (y - 1701) / 100;
+    d += (y - 1601) / 400;
+  }
 
-/*
- *	great calendar changeover instant
- */
+  /*
+   *	great calendar changeover instant
+   */
 
-	if(y > 1752)
-		d += 3;
+  if (y > 1752)
+    d += 3;
 
-	return(d%7);
+  return (d % 7);
 }

--- a/src/cmd/cat.c
+++ b/src/cmd/cat.c
@@ -4,6 +4,10 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file cat.c
+ * @brief Concatenate files.
+ */
 
 /*
  *  cat	- conCATenate and print
@@ -23,95 +27,99 @@
 static char Sccsid[] = "@(#)cat.c	3.0	4/21/86";
 
 #include <stdio.h>
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
-char	stdbuf[BUFSIZ];
-int	bflg, eflg, nflg, sflg, tflg, vflg;
-int	spaced, col, lno, inline;
+char stdbuf[BUFSIZ];
+int bflg, eflg, nflg, sflg, tflg, vflg;
+int spaced, col, lno, inline;
 
-main(argc, argv)
-char **argv;
-{
-	int fflg = 0;
-	register FILE *fi;
-	register c;
-	int dev, ino = -1;
-	struct stat statb;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  int fflg = 0;
+  register FILE *fi;
+  register c;
+  int dev, ino = -1;
+  struct stat statb;
 
-	lno = 1;
-	setbuf(stdout, stdbuf);
-	for( ; argc>1 && argv[1][0]=='-'; argc--,argv++) {
-		switch(argv[1][1]) {
-		case 0:
-			break;
-		case 'u':
-			setbuf(stdout, (char *)NULL);
-			continue;
-		case 'n':
-			nflg++;
-			continue;
-		case 'b':
-			bflg++;
-			nflg++;
-			continue;
-		case 'v':
-			vflg++;
-			continue;
-		case 's':
-			sflg++;
-			continue;
-		case 'e':
-			eflg++;
-			continue;
-		case 't':
-			tflg++;
-			vflg++;
-			continue;
-		}
-		break;
-	}
-	if (fstat(fileno(stdout), &statb) == 0) {
-		statb.st_mode &= S_IFMT;
-		if (statb.st_mode!=S_IFCHR && statb.st_mode!=S_IFBLK) {
-			dev = statb.st_dev;
-			ino = statb.st_ino;
-		}
-	}
-	if (argc < 2) {
-		argc = 2;
-		fflg++;
-	}
-	while (--argc > 0) {
-		if (fflg || (*++argv)[0]=='-' && (*argv)[1]=='\0')
-			fi = stdin;
-		else {
-			if ((fi = fopen(*argv, "r")) == NULL) {
-				perror(*argv);
-				continue;
-			}
-		}
-		if (fstat(fileno(fi), &statb) == 0) {
-			if ((statb.st_mode & S_IFMT) == S_IFREG &&
-			    statb.st_dev==dev && statb.st_ino==ino) {
-				fprintf(stderr, "cat: input %s is output\n",
-				   fflg?"-": *argv);
-				fclose(fi);
-				continue;
-			}
-		}
-		if (nflg||sflg||vflg||eflg)
-			copyopt(fi);
-		else {
-			while ((c = getc(fi)) != EOF)
-				putchar(c);
-		}
-		if (fi!=stdin)
-			fclose(fi);
-	}
-	if (ferror(stdout))
-		fprintf(stderr, "cat: output write error\n");
-	return(0);
+  lno = 1;
+  setbuf(stdout, stdbuf);
+  for (; argc > 1 && argv[1][0] == '-'; argc--, argv++) {
+    switch (argv[1][1]) {
+    case 0:
+      break;
+    case 'u':
+      setbuf(stdout, (char *)NULL);
+      continue;
+    case 'n':
+      nflg++;
+      continue;
+    case 'b':
+      bflg++;
+      nflg++;
+      continue;
+    case 'v':
+      vflg++;
+      continue;
+    case 's':
+      sflg++;
+      continue;
+    case 'e':
+      eflg++;
+      continue;
+    case 't':
+      tflg++;
+      vflg++;
+      continue;
+    }
+    break;
+  }
+  if (fstat(fileno(stdout), &statb) == 0) {
+    statb.st_mode &= S_IFMT;
+    if (statb.st_mode != S_IFCHR && statb.st_mode != S_IFBLK) {
+      dev = statb.st_dev;
+      ino = statb.st_ino;
+    }
+  }
+  if (argc < 2) {
+    argc = 2;
+    fflg++;
+  }
+  while (--argc > 0) {
+    if (fflg || (*++argv)[0] == '-' && (*argv)[1] == '\0')
+      fi = stdin;
+    else {
+      if ((fi = fopen(*argv, "r")) == NULL) {
+        perror(*argv);
+        continue;
+      }
+    }
+    if (fstat(fileno(fi), &statb) == 0) {
+      if ((statb.st_mode & S_IFMT) == S_IFREG && statb.st_dev == dev &&
+          statb.st_ino == ino) {
+        fprintf(stderr, "cat: input %s is output\n", fflg ? "-" : *argv);
+        fclose(fi);
+        continue;
+      }
+    }
+    if (nflg || sflg || vflg || eflg)
+      copyopt(fi);
+    else {
+      while ((c = getc(fi)) != EOF)
+        putchar(c);
+    }
+    if (fi != stdin)
+      fclose(fi);
+  }
+  if (ferror(stdout))
+    fprintf(stderr, "cat: output write error\n");
+  return (0);
 }
 
 /*
@@ -120,49 +128,48 @@ char **argv;
  *  Implement copy options.  Called if any major option is
  *  set.
  */
-copyopt(f)
-	register FILE *f;
+copyopt(f) register FILE *f;
 {
-	register int c;
+  register int c;
 
 top:
-	c = getc(f);
-	if (c == EOF)
-		return;
-	if (c == '\n') {
-		if (inline == 0) {
-			if (sflg && spaced)
-				goto top;
-			spaced = 1;
-		}
-		if (nflg && bflg==0 && inline == 0)
-			printf("%6d\t", lno++);
-		if (eflg)
-			putchar('$');
-		putchar('\n');
-		inline = 0;
-		goto top;
-	}
-	if (nflg && inline == 0)
-		printf("%6d\t", lno++);
-	inline = 1;
-	if (vflg) {
-		if (tflg==0 && c == '\t')
-			putchar(c);
-		else {
-			if (c > 0177) {
-				printf("M-");
-				c &= 0177;
-			}
-			if (c < ' ')
-				printf("^%c", c+'@');
-			else if (c == 0177)
-				printf("^?");
-			else
-				putchar(c);
-		}
-	} else
-		putchar(c);
-	spaced = 0;
-	goto top;
+  c = getc(f);
+  if (c == EOF)
+    return;
+  if (c == '\n') {
+    if (inline == 0) {
+      if (sflg && spaced)
+        goto top;
+      spaced = 1;
+    }
+    if (nflg && bflg == 0 && inline == 0)
+      printf("%6d\t", lno++);
+    if (eflg)
+      putchar('$');
+    putchar('\n');
+    inline = 0;
+    goto top;
+  }
+  if (nflg && inline == 0)
+    printf("%6d\t", lno++);
+  inline = 1;
+  if (vflg) {
+    if (tflg == 0 && c == '\t')
+      putchar(c);
+    else {
+      if (c > 0177) {
+        printf("M-");
+        c &= 0177;
+      }
+      if (c < ' ')
+        printf("^%c", c + '@');
+      else if (c == 0177)
+        printf("^?");
+      else
+        putchar(c);
+    }
+  } else
+    putchar(c);
+  spaced = 0;
+  goto top;
 }

--- a/src/cmd/catman.c
+++ b/src/cmd/catman.c
@@ -4,6 +4,10 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file catman.c
+ * @brief Update man page database.
+ */
 
 #ifndef lint
 static char Sccsid[] = "@(#)catman.c 3.0 4/21/86";
@@ -15,147 +19,145 @@ static char Sccsid[] = "@(#)catman.c 3.0 4/21/86";
  * catman: update cat'able versions of manual pages
  *  (whatis database also)
  */
-#include <stdio.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <time.h>
-#include <ndir.h>
 #include <ctype.h>
+#include <ndir.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
 
-#define SYSTEM(str)     (pflag ? printf("%s\n", str) : system(str))
+#define SYSTEM(str) (pflag ? printf("%s\n", str) : system(str))
 
-char    buf[BUFSIZ];
-char    pflag;
-char    nflag;
-char    wflag;
-char    man[MAXNAMLEN+6] = "manx/";
-char    cat[MAXNAMLEN+6] = "catx/";
-char    *rindex();
+char buf[BUFSIZ];
+char pflag;
+char nflag;
+char wflag;
+char man[MAXNAMLEN + 6] = "manx/";
+char cat[MAXNAMLEN + 6] = "catx/";
+char *rindex();
 
-main(ac, av)
-        int ac;
-        char *av[];
+main(ac, av) int ac;
+char *av[];
 {
-        register char *msp, *csp, *sp;
-        register char *sections;
-        register int exstat = 0;
-        register char changed = 0;
+  register char *msp, *csp, *sp;
+  register char *sections;
+  register int exstat = 0;
+  register char changed = 0;
 
-        while (ac > 1) {
-                av++;
-                if (strcmp(*av, "-p") == 0)
-                        pflag++;
-                else if (strcmp(*av, "-n") == 0)
-                        nflag++;
-                else if (strcmp(*av, "-w") == 0)
-                        wflag++;
-                else if (*av[0] == '-')
-                        goto usage;
-                else
-                        break;
-                ac--;
-        }
-        if (ac == 2)
-                sections = *av;
-        else if (ac < 2)
-                sections = "12345678";
-        else {
-usage:
-                printf("usage: catman [ -p ] [ -n ] [ -w ] [ sections ]\n");
-                exit(-1);
-        }
-        if (wflag)
-                goto whatis;
-        chdir("/usr/man");
-        msp = &man[5];
-        csp = &cat[5];
-        umask(0);
-        for (sp = sections; *sp; sp++) {
-                register DIR *mdir;
-                register struct direct *dir;
-                struct stat sbuf;
+  while (ac > 1) {
+    av++;
+    if (strcmp(*av, "-p") == 0)
+      pflag++;
+    else if (strcmp(*av, "-n") == 0)
+      nflag++;
+    else if (strcmp(*av, "-w") == 0)
+      wflag++;
+    else if (*av[0] == '-')
+      goto usage;
+    else
+      break;
+    ac--;
+  }
+  if (ac == 2)
+    sections = *av;
+  else if (ac < 2)
+    sections = "12345678";
+  else {
+  usage:
+    printf("usage: catman [ -p ] [ -n ] [ -w ] [ sections ]\n");
+    exit(-1);
+  }
+  if (wflag)
+    goto whatis;
+  chdir("/usr/man");
+  msp = &man[5];
+  csp = &cat[5];
+  umask(0);
+  for (sp = sections; *sp; sp++) {
+    register DIR *mdir;
+    register struct direct *dir;
+    struct stat sbuf;
 
-                man[3] = cat[3] = *sp;
-                *msp = *csp = '\0';
-                if ((mdir = opendir(man)) == NULL) {
-                        fprintf(stderr, "opendir:");
-                        perror(man);
-                        exstat = 1;
-                        continue;
-                }
-                if (stat(cat, &sbuf) < 0) {
-                        char buf[MAXNAMLEN + 6], *cp, *rindex();
+    man[3] = cat[3] = *sp;
+    *msp = *csp = '\0';
+    if ((mdir = opendir(man)) == NULL) {
+      fprintf(stderr, "opendir:");
+      perror(man);
+      exstat = 1;
+      continue;
+    }
+    if (stat(cat, &sbuf) < 0) {
+      char buf[MAXNAMLEN + 6], *cp, *rindex();
 
-                        strcpy(buf, cat);
-                        cp = rindex(buf, '/');
-                        if (cp && cp[1] == '\0')
-                                *cp = '\0';
-                        if (pflag)
-                                printf("mkdir %s\n", buf);
-                        else if (mkdir(buf, 0777) < 0) {
-                                sprintf(buf, "catman: mkdir: %s", cat);
-                                perror(buf);
-                                continue;
-                        }
-                        stat(cat, &sbuf);
-                }
-                if ((sbuf.st_mode & 0777) != 0777)
-                        chmod(cat, 0777);
-                while ((dir = readdir(mdir)) != NULL) {
-                        time_t time;
-                        char *tsp;
-                        FILE *inf;
+      strcpy(buf, cat);
+      cp = rindex(buf, '/');
+      if (cp && cp[1] == '\0')
+        *cp = '\0';
+      if (pflag)
+        printf("mkdir %s\n", buf);
+      else if (mkdir(buf, 0777) < 0) {
+        sprintf(buf, "catman: mkdir: %s", cat);
+        perror(buf);
+        continue;
+      }
+      stat(cat, &sbuf);
+    }
+    if ((sbuf.st_mode & 0777) != 0777)
+      chmod(cat, 0777);
+    while ((dir = readdir(mdir)) != NULL) {
+      time_t time;
+      char *tsp;
+      FILE *inf;
 
-                        if (dir->d_ino == 0 || dir->d_name[0] == '.')
-                                continue;
-                        /*
-                         * Make sure this is a man file, i.e., that it
-                         * ends in .[0-9] or .[0-9][a-z]
-                         */
-                        tsp = rindex(dir->d_name, '.');
-                        if (tsp == NULL)
-                                continue;
-                        if (!isdigit(*++tsp))
-                                continue;
-                        if (*++tsp && !isalpha(*tsp))
-                                continue;
-                        if (*tsp && *++tsp)
-                                continue;
-                        strcpy(msp, dir->d_name);
-                        if ((inf = fopen(man, "r")) == NULL) {
-                                perror(man);
-                                exstat = 1;
-                                continue;
-                        }
-                        if (getc(inf) == '.' && getc(inf) == 's'
-                            && getc(inf) == 'o') {
-                                fclose(inf);
-                                continue;
-                        }
-                        fclose(inf);
-                        strcpy(csp, dir->d_name);
-                        if (stat(cat, &sbuf) >= 0) {
-                                time = sbuf.st_mtime;
-                                stat(man, &sbuf);
-                                if (time >= sbuf.st_mtime)
-                                        continue;
-                                unlink(cat);
-                        }
-                        sprintf(buf, "nroff -man %s > %s", man, cat);
-                        SYSTEM(buf);
-                        changed = 1;
-                }
-                closedir(mdir);
-        }
-        if (changed && !nflag) {
-whatis:
-                if (pflag)
-                        printf("/bin/sh /usr/lib/makewhatis\n");
-                else {
-                        execl("/bin/sh", "/bin/sh", "/usr/lib/makewhatis", 0);
-                        perror("/bin/sh /usr/lib/makewhatis");
-                        exstat = 1;
-                }
-        }
-        exit(exstat);
+      if (dir->d_ino == 0 || dir->d_name[0] == '.')
+        continue;
+      /*
+       * Make sure this is a man file, i.e., that it
+       * ends in .[0-9] or .[0-9][a-z]
+       */
+      tsp = rindex(dir->d_name, '.');
+      if (tsp == NULL)
+        continue;
+      if (!isdigit(*++tsp))
+        continue;
+      if (*++tsp && !isalpha(*tsp))
+        continue;
+      if (*tsp && *++tsp)
+        continue;
+      strcpy(msp, dir->d_name);
+      if ((inf = fopen(man, "r")) == NULL) {
+        perror(man);
+        exstat = 1;
+        continue;
+      }
+      if (getc(inf) == '.' && getc(inf) == 's' && getc(inf) == 'o') {
+        fclose(inf);
+        continue;
+      }
+      fclose(inf);
+      strcpy(csp, dir->d_name);
+      if (stat(cat, &sbuf) >= 0) {
+        time = sbuf.st_mtime;
+        stat(man, &sbuf);
+        if (time >= sbuf.st_mtime)
+          continue;
+        unlink(cat);
+      }
+      sprintf(buf, "nroff -man %s > %s", man, cat);
+      SYSTEM(buf);
+      changed = 1;
+    }
+    closedir(mdir);
+  }
+  if (changed && !nflag) {
+  whatis:
+    if (pflag)
+      printf("/bin/sh /usr/lib/makewhatis\n");
+    else {
+      execl("/bin/sh", "/bin/sh", "/usr/lib/makewhatis", 0);
+      perror("/bin/sh /usr/lib/makewhatis");
+      exstat = 1;
+    }
+  }
+  exit(exstat);
 }

--- a/src/cmd/cb.c
+++ b/src/cmd/cb.c
@@ -4,370 +4,387 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file cb.c
+ * @brief C program beautifier.
+ */
 
 static char Sccsid[] = "@(#)cb.c 3.0 4/21/86";
 #include <stdio.h>
-int	slevel[10];
-int	clevel	= 0;
-int	spflg[20][10];
-int	sind[20][10];
-int	siflev[10];
-int	sifflg[10];
-int	iflev	= 0;
-int	ifflg	= -1;
-int	level	= 0;
-int	ind[10]	= {
-	0,0,0,0,0,0,0,0,0,0 };
-int	eflg	= 0;
-int	paren	= 0;
-int	pflg[10] = {
-	0,0,0,0,0,0,0,0,0,0 };
-char	lchar;
-char	pchar;
-int	aflg	= 0;
-int	ct;
-int	stabs[20][10];
-int	qflg	= 0;
-char	*wif[] = {
-	"if",0};
-char	*welse[] = {
-	"else",0};
-char	*wfor[] = {
-	"for",0};
-char	*wds[] = {
-	"case","default",0};
-int	j	= 0;
-char	string[200];
-char	cc;
-int	sflg	= 1;
-int	peek	= -1;
-int	tabs	= 0;
-int	lastchar;
-int	c;
-main(argc,argv) int argc;
+int slevel[10];
+int clevel = 0;
+int spflg[20][10];
+int sind[20][10];
+int siflev[10];
+int sifflg[10];
+int iflev = 0;
+int ifflg = -1;
+int level = 0;
+int ind[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+int eflg = 0;
+int paren = 0;
+int pflg[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+char lchar;
+char pchar;
+int aflg = 0;
+int ct;
+int stabs[20][10];
+int qflg = 0;
+char *wif[] = {"if", 0};
+char *welse[] = {"else", 0};
+char *wfor[] = {"for", 0};
+char *wds[] = {"case", "default", 0};
+int j = 0;
+char string[200];
+char cc;
+int sflg = 1;
+int peek = -1;
+int tabs = 0;
+int lastchar;
+int c;
+main(argc, argv) int argc;
 char argv[];
 {
-	while((c = getch()) != EOF){
-		switch(c){
-		case ' ':
-		case '\t':
-			if(lookup(welse) == 1){
-				gotelse();
-				if(sflg == 0 || j > 0)string[j++] = c;
-				puts();
-				sflg = 0;
-				if(getnl() == 1){
-					puts();
-					printf("\n");
-					sflg = 1;
-					pflg[level]++;
-					tabs++;
-				}
-				continue;
-			}
-			if(sflg == 0 || j > 0)string[j++] = c;
-			continue;
-		case '\n':
-			if((eflg = lookup(welse)) == 1)gotelse();
-			puts();
-			printf("\n");
-			sflg = 1;
-			if(eflg == 1){
-				pflg[level]++;
-				tabs++;
-			}
-			else
-				if(pchar == lchar)
-					aflg = 1;
-			continue;
-		case '{':
-			if(lookup(welse) == 1)gotelse();
-			siflev[clevel] = iflev;
-			sifflg[clevel] = ifflg;
-			iflev = ifflg = 0;
-			clevel++;
-			if(sflg == 1 && pflg[level] != 0){
-				pflg[level]--;
-				tabs--;
-			}
-			string[j++] = c;
-			puts();
-			getnl();
-			puts();
-			printf("\n");
-			tabs++;
-			sflg = 1;
-			if(pflg[level] > 0){
-				ind[level] = 1;
-				level++;
-				slevel[level] = clevel;
-			}
-			continue;
-		case '}':
-			clevel--;
-			if((iflev = siflev[clevel]-1) < 0)iflev = 0;
-			ifflg = sifflg[clevel];
-			if(pflg[level] >0 && ind[level] == 0){
-				tabs -= pflg[level];
-				pflg[level] = 0;
-			}
-			puts();
-			tabs--;
-			ptabs();
-			if((peek = getch()) == ';'){
-				printf("%c;",c);
-				peek = -1;
-			}
-			else printf("%c",c);
-			getnl();
-			puts();
-			printf("\n");
-			sflg = 1;
-			if(clevel < slevel[level])if(level > 0)level--;
-			if(ind[level] != 0){
-				tabs -= pflg[level];
-				pflg[level] = 0;
-				ind[level] = 0;
-			}
-			continue;
-		case '"':
-		case '\'':
-			string[j++] = c;
-			while((cc = getch()) != c){
-				string[j++] = cc;
-				if(cc == '\\'){
-					string[j++] = getch();
-				}
-				if(cc == '\n'){
-					puts();
-					sflg = 1;
-				}
-			}
-			string[j++] = cc;
-			if(getnl() == 1){
-				lchar = cc;
-				peek = '\n';
-			}
-			continue;
-		case ';':
-			string[j++] = c;
-			puts();
-			if(pflg[level] > 0 && ind[level] == 0){
-				tabs -= pflg[level];
-				pflg[level] = 0;
-			}
-			getnl();
-			puts();
-			printf("\n");
-			sflg = 1;
-			if(iflev > 0)
-				if(ifflg == 1){iflev--;
-					ifflg = 0;
-				}
-				else iflev = 0;
-			continue;
-		case '\\':
-			string[j++] = c;
-			string[j++] = getch();
-			continue;
-		case '?':
-			qflg = 1;
-			string[j++] = c;
-			continue;
-		case ':':
-			string[j++] = c;
-			if(qflg == 1){
-				qflg = 0;
-				continue;
-			}
-			if(lookup(wds) == 0){
-				sflg = 0;
-				puts();
-			}
-			else{
-				tabs--;
-				puts();
-				tabs++;
-			}
-			if((peek = getch()) == ';'){
-				printf(";");
-				peek = -1;
-			}
-			getnl();
-			puts();
-			printf("\n");
-			sflg = 1;
-			continue;
-		case '/':
-			string[j++] = c;
-			if((peek = getch()) != '*')continue;
-			string[j++] = peek;
-			peek = -1;
-			comment();
-			continue;
-		case ')':
-			paren--;
-			string[j++] = c;
-			puts();
-			if(getnl() == 1){
-				peek = '\n';
-				if(paren != 0)aflg = 1;
-				else if(tabs > 0){
-					pflg[level]++;
-					tabs++;
-					ind[level] = 0;
-				}
-			}
-			continue;
-		case '#':
-			string[j++] = c;
-			while((cc = getch()) != '\n')string[j++] = cc;
-			string[j++] = cc;
-			sflg = 0;
-			puts();
-			sflg = 1;
-			continue;
-		case '(':
-			string[j++] = c;
-			paren++;
-			if(lookup(wfor) == 1){
-				while((c = cb_gets()) != ';');
-				ct=0;
-cont:
-				while((c = cb_gets()) != ')'){
-					if(c == '(') ct++;
-				}
-				if(ct != 0){
-					ct--;
-					goto cont;
-				}
-				paren--;
-				puts();
-				if(getnl() == 1){
-					peek = '\n';
-					pflg[level]++;
-					tabs++;
-					ind[level] = 0;
-				}
-				continue;
-			}
-			if(lookup(wif) == 1){
-				puts();
-				stabs[clevel][iflev] = tabs;
-				spflg[clevel][iflev] = pflg[level];
-				sind[clevel][iflev] = ind[level];
-				iflev++;
-				ifflg = 1;
-			}
-			continue;
-		default:
-			string[j++] = c;
-			if(c != ',')lchar = c;
-		}
-	}
+  while ((c = getch()) != EOF) {
+    switch (c) {
+    case ' ':
+    case '\t':
+      if (lookup(welse) == 1) {
+        gotelse();
+        if (sflg == 0 || j > 0)
+          string[j++] = c;
+        puts();
+        sflg = 0;
+        if (getnl() == 1) {
+          puts();
+          printf("\n");
+          sflg = 1;
+          pflg[level]++;
+          tabs++;
+        }
+        continue;
+      }
+      if (sflg == 0 || j > 0)
+        string[j++] = c;
+      continue;
+    case '\n':
+      if ((eflg = lookup(welse)) == 1)
+        gotelse();
+      puts();
+      printf("\n");
+      sflg = 1;
+      if (eflg == 1) {
+        pflg[level]++;
+        tabs++;
+      } else if (pchar == lchar)
+        aflg = 1;
+      continue;
+    case '{':
+      if (lookup(welse) == 1)
+        gotelse();
+      siflev[clevel] = iflev;
+      sifflg[clevel] = ifflg;
+      iflev = ifflg = 0;
+      clevel++;
+      if (sflg == 1 && pflg[level] != 0) {
+        pflg[level]--;
+        tabs--;
+      }
+      string[j++] = c;
+      puts();
+      getnl();
+      puts();
+      printf("\n");
+      tabs++;
+      sflg = 1;
+      if (pflg[level] > 0) {
+        ind[level] = 1;
+        level++;
+        slevel[level] = clevel;
+      }
+      continue;
+    case '}':
+      clevel--;
+      if ((iflev = siflev[clevel] - 1) < 0)
+        iflev = 0;
+      ifflg = sifflg[clevel];
+      if (pflg[level] > 0 && ind[level] == 0) {
+        tabs -= pflg[level];
+        pflg[level] = 0;
+      }
+      puts();
+      tabs--;
+      ptabs();
+      if ((peek = getch()) == ';') {
+        printf("%c;", c);
+        peek = -1;
+      } else
+        printf("%c", c);
+      getnl();
+      puts();
+      printf("\n");
+      sflg = 1;
+      if (clevel < slevel[level])
+        if (level > 0)
+          level--;
+      if (ind[level] != 0) {
+        tabs -= pflg[level];
+        pflg[level] = 0;
+        ind[level] = 0;
+      }
+      continue;
+    case '"':
+    case '\'':
+      string[j++] = c;
+      while ((cc = getch()) != c) {
+        string[j++] = cc;
+        if (cc == '\\') {
+          string[j++] = getch();
+        }
+        if (cc == '\n') {
+          puts();
+          sflg = 1;
+        }
+      }
+      string[j++] = cc;
+      if (getnl() == 1) {
+        lchar = cc;
+        peek = '\n';
+      }
+      continue;
+    case ';':
+      string[j++] = c;
+      puts();
+      if (pflg[level] > 0 && ind[level] == 0) {
+        tabs -= pflg[level];
+        pflg[level] = 0;
+      }
+      getnl();
+      puts();
+      printf("\n");
+      sflg = 1;
+      if (iflev > 0)
+        if (ifflg == 1) {
+          iflev--;
+          ifflg = 0;
+        } else
+          iflev = 0;
+      continue;
+    case '\\':
+      string[j++] = c;
+      string[j++] = getch();
+      continue;
+    case '?':
+      qflg = 1;
+      string[j++] = c;
+      continue;
+    case ':':
+      string[j++] = c;
+      if (qflg == 1) {
+        qflg = 0;
+        continue;
+      }
+      if (lookup(wds) == 0) {
+        sflg = 0;
+        puts();
+      } else {
+        tabs--;
+        puts();
+        tabs++;
+      }
+      if ((peek = getch()) == ';') {
+        printf(";");
+        peek = -1;
+      }
+      getnl();
+      puts();
+      printf("\n");
+      sflg = 1;
+      continue;
+    case '/':
+      string[j++] = c;
+      if ((peek = getch()) != '*')
+        continue;
+      string[j++] = peek;
+      peek = -1;
+      comment();
+      continue;
+    case ')':
+      paren--;
+      string[j++] = c;
+      puts();
+      if (getnl() == 1) {
+        peek = '\n';
+        if (paren != 0)
+          aflg = 1;
+        else if (tabs > 0) {
+          pflg[level]++;
+          tabs++;
+          ind[level] = 0;
+        }
+      }
+      continue;
+    case '#':
+      string[j++] = c;
+      while ((cc = getch()) != '\n')
+        string[j++] = cc;
+      string[j++] = cc;
+      sflg = 0;
+      puts();
+      sflg = 1;
+      continue;
+    case '(':
+      string[j++] = c;
+      paren++;
+      if (lookup(wfor) == 1) {
+        while ((c = cb_gets()) != ';')
+          ;
+        ct = 0;
+      cont:
+        while ((c = cb_gets()) != ')') {
+          if (c == '(')
+            ct++;
+        }
+        if (ct != 0) {
+          ct--;
+          goto cont;
+        }
+        paren--;
+        puts();
+        if (getnl() == 1) {
+          peek = '\n';
+          pflg[level]++;
+          tabs++;
+          ind[level] = 0;
+        }
+        continue;
+      }
+      if (lookup(wif) == 1) {
+        puts();
+        stabs[clevel][iflev] = tabs;
+        spflg[clevel][iflev] = pflg[level];
+        sind[clevel][iflev] = ind[level];
+        iflev++;
+        ifflg = 1;
+      }
+      continue;
+    default:
+      string[j++] = c;
+      if (c != ',')
+        lchar = c;
+    }
+  }
 }
-ptabs(){
-	int i;
-	for(i=0; i < tabs; i++)printf("\t");
+ptabs() {
+  int i;
+  for (i = 0; i < tabs; i++)
+    printf("\t");
 }
-getch(){
-	if(peek < 0 && lastchar != ' ' && lastchar != '\t')pchar = lastchar;
-	lastchar = (peek<0) ? getc(stdin):peek;
-	peek = -1;
-	return(lastchar);
+getch() {
+  if (peek < 0 && lastchar != ' ' && lastchar != '\t')
+    pchar = lastchar;
+  lastchar = (peek < 0) ? getc(stdin) : peek;
+  peek = -1;
+  return (lastchar);
 }
-puts(){
-	if(j > 0){
-		if(sflg != 0){
-			ptabs();
-			sflg = 0;
-			if(aflg == 1){
-				aflg = 0;
-				if(tabs > 0)printf("    ");
-			}
-		}
-		string[j] = '\0';
-		printf("%s",string);
-		j = 0;
-	}
-	else{
-		if(sflg != 0){
-			sflg = 0;
-			aflg = 0;
-		}
-	}
+puts() {
+  if (j > 0) {
+    if (sflg != 0) {
+      ptabs();
+      sflg = 0;
+      if (aflg == 1) {
+        aflg = 0;
+        if (tabs > 0)
+          printf("    ");
+      }
+    }
+    string[j] = '\0';
+    printf("%s", string);
+    j = 0;
+  } else {
+    if (sflg != 0) {
+      sflg = 0;
+      aflg = 0;
+    }
+  }
 }
-lookup(tab)
-char *tab[];
+lookup(tab) char *tab[];
 {
-	char r;
-	int l,kk,k,i;
-	if(j < 1)return(0);
-	kk=0;
-	while(string[kk] == ' ')kk++;
-	for(i=0; tab[i] != 0; i++){
-		l=0;
-		for(k=kk;(r = tab[i][l++]) == string[k] && r != '\0';k++);
-		if(r == '\0' && (string[k] < 'a' || string[k] > 'z' || k >= j))return(1);
-	}
-	return(0);
+  char r;
+  int l, kk, k, i;
+  if (j < 1)
+    return (0);
+  kk = 0;
+  while (string[kk] == ' ')
+    kk++;
+  for (i = 0; tab[i] != 0; i++) {
+    l = 0;
+    for (k = kk; (r = tab[i][l++]) == string[k] && r != '\0'; k++)
+      ;
+    if (r == '\0' && (string[k] < 'a' || string[k] > 'z' || k >= j))
+      return (1);
+  }
+  return (0);
 }
-cb_gets(){
-	char ch;
+cb_gets() {
+  char ch;
 beg:
-	if((ch = string[j++] = getch()) == '\\'){
-		string[j++] = getch();
-		goto beg;
-	}
-	if(ch == '\'' || ch == '"'){
-		while((cc = string[j++] = getch()) != ch)if(cc == '\\')string[j++] = getch();
-		goto beg;
-	}
-	if(ch == '\n'){
-		puts();
-		aflg = 1;
-		goto beg;
-	}
-	else return(ch);
+  if ((ch = string[j++] = getch()) == '\\') {
+    string[j++] = getch();
+    goto beg;
+  }
+  if (ch == '\'' || ch == '"') {
+    while ((cc = string[j++] = getch()) != ch)
+      if (cc == '\\')
+        string[j++] = getch();
+    goto beg;
+  }
+  if (ch == '\n') {
+    puts();
+    aflg = 1;
+    goto beg;
+  } else
+    return (ch);
 }
-gotelse(){
-	tabs = stabs[clevel][iflev];
-	pflg[level] = spflg[clevel][iflev];
-	ind[level] = sind[clevel][iflev];
-	ifflg = 1;
+gotelse() {
+  tabs = stabs[clevel][iflev];
+  pflg[level] = spflg[clevel][iflev];
+  ind[level] = sind[clevel][iflev];
+  ifflg = 1;
 }
-getnl(){
-	while((peek = getch()) == '\t' || peek == ' '){
-		string[j++] = peek;
-		peek = -1;
-	}
-	if((peek = getch()) == '/'){
-		peek = -1;
-		if((peek = getch()) == '*'){
-			string[j++] = '/';
-			string[j++] = '*';
-			peek = -1;
-			comment();
-		}
-		else string[j++] = '/';
-	}
-	if((peek = getch()) == '\n'){
-		peek = -1;
-		return(1);
-	}
-	return(0);
+getnl() {
+  while ((peek = getch()) == '\t' || peek == ' ') {
+    string[j++] = peek;
+    peek = -1;
+  }
+  if ((peek = getch()) == '/') {
+    peek = -1;
+    if ((peek = getch()) == '*') {
+      string[j++] = '/';
+      string[j++] = '*';
+      peek = -1;
+      comment();
+    } else
+      string[j++] = '/';
+  }
+  if ((peek = getch()) == '\n') {
+    peek = -1;
+    return (1);
+  }
+  return (0);
 }
-comment(){
-	while((c = string[j++] = getch()) != '*'){
-rep:
-		if(c == '\n'){
-			puts();
-			sflg = 1;
-		}
-	}
+comment() {
+  while ((c = string[j++] = getch()) != '*') {
+  rep:
+    if (c == '\n') {
+      puts();
+      sflg = 1;
+    }
+  }
 gotstar:
-	if((c = string[j++] = getch()) != '/'){
-		if(c == '*')goto gotstar;
-		goto rep;
-	}
+  if ((c = string[j++] = getch()) != '/') {
+    if (c == '*')
+      goto gotstar;
+    goto rep;
+  }
 }

--- a/src/cmd/cc.c
+++ b/src/cmd/cc.c
@@ -4,31 +4,35 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file cc.c
+ * @brief C compiler driver.
+ */
 
 #
 static char Sccsid[] = "@(#)cc.c 3.0 4/21/86";
-# include <stdio.h>
-# include <ctype.h>
-# include <signal.h>
+#include <ctype.h>
+#include <signal.h>
+#include <stdio.h>
 
 /* cc - front end for C compiler */
 
-# define MAXINC 10
-# define MAXFIL 100
-# define MAXLIB 100
-# define MAXOPT 100
-# define CHSPACE 1000
-char	tmp0[16];
-char	*tmp1, *tmp2, *tmp3, *tmp4, *tmp5;
-char	*outfile;
-char	ts[CHSPACE+50];
-char	*tsa = ts;
-char	*tsp = ts;
-char	*av[50];
-char	*clist[MAXFIL];
-char	*llist[MAXLIB];
-int	pflag, sflag, cflag, eflag, exflag, oflag, proflag, noflflag;
-int	sys_V_flag;	/* true if System V prog. env. was specified */
+#define MAXINC 10
+#define MAXFIL 100
+#define MAXLIB 100
+#define MAXOPT 100
+#define CHSPACE 1000
+char tmp0[16];
+char *tmp1, *tmp2, *tmp3, *tmp4, *tmp5;
+char *outfile;
+char ts[CHSPACE + 50];
+char *tsa = ts;
+char *tsp = ts;
+char *av[50];
+char *clist[MAXFIL];
+char *llist[MAXLIB];
+int pflag, sflag, cflag, eflag, exflag, oflag, proflag, noflflag;
+int sys_V_flag; /* true if System V prog. env. was specified */
 /*
  * Vflag now defaults to 1.  This is so that
  * we can get rid of the overlay libraries and
@@ -36,547 +40,538 @@ int	sys_V_flag;	/* true if System V prog. env. was specified */
  * for both overlay and non-overlay code.
  * 6/18/84 -Dave Borman
  */
-int	Vflag = 1;		/* for overlays */
-int	Nflag = 0;	/* put switch tables into text space */
-char	*chpass ;
-char	*npassname ;
-char	right_c2[6];	/* is either c2_ov or c2_id, used with -B */
-char	pass0[20] = "/lib/c0";
-char	pass1[20] = "/lib/c1";
-char	pass2[23] = "/lib/c2_ov"; /* set to c2_id if /unix is 0411 type kernel */
-char	passp[20] = "/lib/cpp";
-char	*pref = "/lib/crt0.o";
-char	*copy();
-char	*setsuf();
-char	*strcat();
-char	*strcpy();
+int Vflag = 1; /* for overlays */
+int Nflag = 0; /* put switch tables into text space */
+char *chpass;
+char *npassname;
+char right_c2[6]; /* is either c2_ov or c2_id, used with -B */
+char pass0[20] = "/lib/c0";
+char pass1[20] = "/lib/c1";
+char pass2[23] = "/lib/c2_ov"; /* set to c2_id if /unix is 0411 type kernel */
+char passp[20] = "/lib/cpp";
+char *pref = "/lib/crt0.o";
+char *copy();
+char *setsuf();
+char *strcat();
+char *strcpy();
 
-int k, debug_printout;	/* debug_printout option, print each pass on stdout */
+int k, debug_printout; /* debug_printout option, print each pass on stdout */
 
-main(argc, argv)
-char *argv[];
-{
-	char *t;
-	char *savetsp;
-	char *assource;
-	char **pv, *ptemp[MAXOPT], **pvt;
-	int nc, nl, i, j, c, f20, nxo, na;
-	int idexit();
-
-/*
- * Change optimizer pass to /lib/c2_id if running
- * separate I & D kernel (0411).
- * Physical location 0 tells which type of kernel.
- * 0 = 3 for OV, 0 = 4 for SID
- * Comments in /usr/src/cmd/mkconf/mkc_str.c warn not to change
- * location zero without checking cc.c first.
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
  */
-	strcpy(right_c2, "c2_ov");	/* default if "-B" */
-	if((i = open("/dev/mem", 0)) >= 0) {
-		read(i, (char *)&nl, sizeof(int));
-		if(nl == 4) {
-			pass2[8] = 'i';
-			pass2[9] = 'd';
-			strcpy(right_c2, "c2_id"); /* for "-B" */
-		}
-		close(i);
-	}
-	i = nc = nl = f20 = nxo = sys_V_flag = 0;
-	debug_printout = 0;
-	setbuf(stdout, (char *)NULL);
-	pv = ptemp;
-	/*
-	 * Check for Programming Environment,
-	 * If it is SYSTEM_FIVE, then set up
-	 * for System V environment.
-	 */
-	if (strcmp("SYSTEM_FIVE", getenv("PROG_ENV")) == 0) {
-		sys_V_flag++;
-	}
-	if (strcmp("DEBUG5", getenv("PROG_ENV")) == 0) {
-		sys_V_flag++;
-		debug_printout++;
-	}
-	if (strcmp("DEBUG", getenv("PROG_ENV")) == 0) {
-		debug_printout++;
-	}
-	while(++i < argc) {
-		if(*argv[i] == '-') switch (argv[i][1]) {
-		default:
-			goto passa;
-		case 'Y':
-			if (!sys_V_flag)
-				sys_V_flag++;
-			break;
-		case 'S':
-			sflag++;
-			cflag++;
-			break;
-		case 'o':
-			if (++i < argc) {
-				outfile = argv[i];
-				if ((c=getsuf(outfile))=='c'||c=='o') {
-					error("Would overwrite %s", outfile);
-					exit(8);
-				}
-			}
-			break;
-		case 'O':
-			oflag++;
-			break;
-		case 'p':
-			proflag++;
-			break;
-		case 'E':
-			exflag++;
-		case 'P':
-			pflag++;
-			*pv++ = argv[i];
-		case 'c':
-			cflag++;
-			break;
+int main(int argc, char **argv) {
+  char *t;
+  char *savetsp;
+  char *assource;
+  char **pv, *ptemp[MAXOPT], **pvt;
+  int nc, nl, i, j, c, f20, nxo, na;
+  int idexit();
 
-		case 'f':
-			noflflag++;
-			if (npassname || chpass)
-				error("-f overwrites earlier option", (char *)NULL);
-			npassname = "/lib/f";
-			chpass = "1";
-			break;
+  /*
+   * Change optimizer pass to /lib/c2_id if running
+   * separate I & D kernel (0411).
+   * Physical location 0 tells which type of kernel.
+   * 0 = 3 for OV, 0 = 4 for SID
+   * Comments in /usr/src/cmd/mkconf/mkc_str.c warn not to change
+   * location zero without checking cc.c first.
+   */
+  strcpy(right_c2, "c2_ov"); /* default if "-B" */
+  if ((i = open("/dev/mem", 0)) >= 0) {
+    read(i, (char *)&nl, sizeof(int));
+    if (nl == 4) {
+      pass2[8] = 'i';
+      pass2[9] = 'd';
+      strcpy(right_c2, "c2_id"); /* for "-B" */
+    }
+    close(i);
+  }
+  i = nc = nl = f20 = nxo = sys_V_flag = 0;
+  debug_printout = 0;
+  setbuf(stdout, (char *)NULL);
+  pv = ptemp;
+  /*
+   * Check for Programming Environment,
+   * If it is SYSTEM_FIVE, then set up
+   * for System V environment.
+   */
+  if (strcmp("SYSTEM_FIVE", getenv("PROG_ENV")) == 0) {
+    sys_V_flag++;
+  }
+  if (strcmp("DEBUG5", getenv("PROG_ENV")) == 0) {
+    sys_V_flag++;
+    debug_printout++;
+  }
+  if (strcmp("DEBUG", getenv("PROG_ENV")) == 0) {
+    debug_printout++;
+  }
+  while (++i < argc) {
+    if (*argv[i] == '-')
+      switch (argv[i][1]) {
+      default:
+        goto passa;
+      case 'Y':
+        if (!sys_V_flag)
+          sys_V_flag++;
+        break;
+      case 'S':
+        sflag++;
+        cflag++;
+        break;
+      case 'o':
+        if (++i < argc) {
+          outfile = argv[i];
+          if ((c = getsuf(outfile)) == 'c' || c == 'o') {
+            error("Would overwrite %s", outfile);
+            exit(8);
+          }
+        }
+        break;
+      case 'O':
+        oflag++;
+        break;
+      case 'p':
+        proflag++;
+        break;
+      case 'E':
+        exflag++;
+      case 'P':
+        pflag++;
+        *pv++ = argv[i];
+      case 'c':
+        cflag++;
+        break;
 
-		case '2':
-			if(argv[i][2] == '\0')
-				pref = "/lib/crt2.o";
-			else {
-				pref = "/lib/crt20.o";
-				f20 = 1;
-			}
-			break;
-		case 'D':
-		case 'I':
-		case 'U':
-		case 'C':
-			*pv++ = argv[i];
-			if (pv >= ptemp+MAXOPT) {
-				error("Too many DIUC options", (char *)NULL);
-				--pv;
-			}
-			break;
-		case 't':
-			if (chpass)
-				error("-t overwrites earlier option", (char *)NULL);
-			chpass = argv[i]+2;
-			if (chpass[0]==0)
-				chpass = "012p";
-			break;
+      case 'f':
+        noflflag++;
+        if (npassname || chpass)
+          error("-f overwrites earlier option", (char *)NULL);
+        npassname = "/lib/f";
+        chpass = "1";
+        break;
 
-		case 'B':
-			if (npassname)
-				error("-B overwrites earlier option", (char *)NULL);
-			npassname = argv[i]+2;
-			if (npassname[0]==0)
-				npassname = "/usr/c/o";
-			break;
+      case '2':
+        if (argv[i][2] == '\0')
+          pref = "/lib/crt2.o";
+        else {
+          pref = "/lib/crt20.o";
+          f20 = 1;
+        }
+        break;
+      case 'D':
+      case 'I':
+      case 'U':
+      case 'C':
+        *pv++ = argv[i];
+        if (pv >= ptemp + MAXOPT) {
+          error("Too many DIUC options", (char *)NULL);
+          --pv;
+        }
+        break;
+      case 't':
+        if (chpass)
+          error("-t overwrites earlier option", (char *)NULL);
+        chpass = argv[i] + 2;
+        if (chpass[0] == 0)
+          chpass = "012p";
+        break;
 
-		case 'N': /* put switch tables into text space */
-			Nflag++;
-			break;
+      case 'B':
+        if (npassname)
+          error("-B overwrites earlier option", (char *)NULL);
+        npassname = argv[i] + 2;
+        if (npassname[0] == 0)
+          npassname = "/usr/c/o";
+        break;
 
-		case 'V':
-			/*
-			 * -V means offset for overlays (now
-			 * the default), -V7 means don't.
-			 */
-			Vflag = (argv[i][2] != '7');
-			break;
-		}
-		else {
-passa:
-			t = argv[i];
-			if((c=getsuf(t))=='c' || c=='s'|| exflag) {
-				clist[nc++] = t;
-				if (nc>=MAXFIL) {
-					error("Too many source files", (char *)NULL);
-					exit(1);
-				}
-				t = setsuf(t, 'o');
-			}
-			if (nodup(llist, t)) {
-				llist[nl++] = t;
-				if (nl >= MAXLIB) {
-					error("Too many object/library files", (char *)NULL);
-					exit(1);
-				}
-				if (getsuf(t)=='o')
-					nxo++;
-			}
-		}
-	}
-	if (npassname && chpass ==0)
-		chpass = "012p";
-	if (chpass && npassname==0)	/* -t but no -B option */
-		npassname = "/usr/src/cmd/c/";
-	if (chpass)
-		for (t=chpass; *t; t++) {
-			switch (*t) {
-			case '0':
-				strcpy (pass0, npassname);
-				strcat (pass0, "c0");
-				continue;
-			case '1':
-				strcpy (pass1, npassname);
-				strcat (pass1, "c1");
-				continue;
-			case '2':
-				strcpy (pass2, npassname);
-		/* "right_c2" next is either c2_ov or c2_id, setup earlier */
-				strcat (pass2, right_c2);
-				continue;
-			case 'p':
-				strcpy (passp, npassname);
-				strcat (passp, "cpp");
-				continue;
-			}
-		}
-	if (noflflag)
-		pref = proflag ? "/lib/fmcrt0.o" : "/lib/fcrt0.o";
-	else if (proflag)
-		pref = "/lib/mcrt0.o";
-	if(nc==0)
-		goto nocom;
-	if (pflag==0)
-		sprintf(tmp0, "/tmp/ctm0.%d", getpid());
-	if (signal(SIGINT, SIG_IGN) != SIG_IGN)
-		signal(SIGINT, idexit);
-	if (signal(SIGTERM, SIG_IGN) != SIG_IGN)
-		signal(SIGTERM, idexit);
-	(tmp1 = copy(tmp0))[8] = '1';
-	(tmp2 = copy(tmp0))[8] = '2';
-	(tmp3 = copy(tmp0))[8] = '3';
-	if (oflag)
-		(tmp5 = copy(tmp0))[8] = '5';
-	if (pflag==0)
-		(tmp4 = copy(tmp0))[8] = '4';
-	pvt = pv;
-	for (i=0; i<nc; i++) {
-		if (nc>1)
-			printf("%s:\n", clist[i]);
-		if (getsuf(clist[i])=='s') {
-			assource = clist[i];
-			goto assemble;
-		}
-		else
-			assource = tmp3;
-		if (pflag)
-			tmp4 = setsuf(clist[i], 'i');
-		savetsp = tsp;
-		av[0] = "cpp";
-		av[1] = clist[i];
-		av[2] = exflag ? "-" : tmp4;
-		na = 3;
-		if (sys_V_flag) {
-			av[na++] = "-DSYSTEM_FIVE"; /* used in System V header files */
-		}
-		for(pv=ptemp; pv <pvt; pv++)
-			av[na++] = *pv;
-		av[na++]=0;
+      case 'N': /* put switch tables into text space */
+        Nflag++;
+        break;
 
-		if (debug_printout) {
-			k=0;
-			while (av[k])
-			    printf("%s ",av[k++]);
-			printf("\n");
-		}
+      case 'V':
+        /*
+         * -V means offset for overlays (now
+         * the default), -V7 means don't.
+         */
+        Vflag = (argv[i][2] != '7');
+        break;
+      }
+    else {
+    passa:
+      t = argv[i];
+      if ((c = getsuf(t)) == 'c' || c == 's' || exflag) {
+        clist[nc++] = t;
+        if (nc >= MAXFIL) {
+          error("Too many source files", (char *)NULL);
+          exit(1);
+        }
+        t = setsuf(t, 'o');
+      }
+      if (nodup(llist, t)) {
+        llist[nl++] = t;
+        if (nl >= MAXLIB) {
+          error("Too many object/library files", (char *)NULL);
+          exit(1);
+        }
+        if (getsuf(t) == 'o')
+          nxo++;
+      }
+    }
+  }
+  if (npassname && chpass == 0)
+    chpass = "012p";
+  if (chpass && npassname == 0) /* -t but no -B option */
+    npassname = "/usr/src/cmd/c/";
+  if (chpass)
+    for (t = chpass; *t; t++) {
+      switch (*t) {
+      case '0':
+        strcpy(pass0, npassname);
+        strcat(pass0, "c0");
+        continue;
+      case '1':
+        strcpy(pass1, npassname);
+        strcat(pass1, "c1");
+        continue;
+      case '2':
+        strcpy(pass2, npassname);
+        /* "right_c2" next is either c2_ov or c2_id, setup earlier */
+        strcat(pass2, right_c2);
+        continue;
+      case 'p':
+        strcpy(passp, npassname);
+        strcat(passp, "cpp");
+        continue;
+      }
+    }
+  if (noflflag)
+    pref = proflag ? "/lib/fmcrt0.o" : "/lib/fcrt0.o";
+  else if (proflag)
+    pref = "/lib/mcrt0.o";
+  if (nc == 0)
+    goto nocom;
+  if (pflag == 0)
+    sprintf(tmp0, "/tmp/ctm0.%d", getpid());
+  if (signal(SIGINT, SIG_IGN) != SIG_IGN)
+    signal(SIGINT, idexit);
+  if (signal(SIGTERM, SIG_IGN) != SIG_IGN)
+    signal(SIGTERM, idexit);
+  (tmp1 = copy(tmp0))[8] = '1';
+  (tmp2 = copy(tmp0))[8] = '2';
+  (tmp3 = copy(tmp0))[8] = '3';
+  if (oflag)
+    (tmp5 = copy(tmp0))[8] = '5';
+  if (pflag == 0)
+    (tmp4 = copy(tmp0))[8] = '4';
+  pvt = pv;
+  for (i = 0; i < nc; i++) {
+    if (nc > 1)
+      printf("%s:\n", clist[i]);
+    if (getsuf(clist[i]) == 's') {
+      assource = clist[i];
+      goto assemble;
+    } else
+      assource = tmp3;
+    if (pflag)
+      tmp4 = setsuf(clist[i], 'i');
+    savetsp = tsp;
+    av[0] = "cpp";
+    av[1] = clist[i];
+    av[2] = exflag ? "-" : tmp4;
+    na = 3;
+    if (sys_V_flag) {
+      av[na++] = "-DSYSTEM_FIVE"; /* used in System V header files */
+    }
+    for (pv = ptemp; pv < pvt; pv++)
+      av[na++] = *pv;
+    av[na++] = 0;
 
-		if (callsys(passp, av)) {
-			cflag++;
-			eflag++;
-			continue;
-		}
-		av[1] = tmp4;
-		tsp = savetsp;
-		av[0]= "c0";
-		if (pflag) {
-			cflag++;
-			continue;
-		}
-		av[2] = tmp1;
-		av[3] = tmp2;
-		{
-			int i = 4;
-			if (proflag)
-				av[i++] = "-P";
-			if (Vflag)
-				av[i++] = "-V";
-			av[i] = 0;
-		}
+    if (debug_printout) {
+      k = 0;
+      while (av[k])
+        printf("%s ", av[k++]);
+      printf("\n");
+    }
 
-		if (debug_printout) {
-			k=0;
-			while (av[k])
-			    printf("%s ",av[k++]);
-			printf("\n");
-		}
+    if (callsys(passp, av)) {
+      cflag++;
+      eflag++;
+      continue;
+    }
+    av[1] = tmp4;
+    tsp = savetsp;
+    av[0] = "c0";
+    if (pflag) {
+      cflag++;
+      continue;
+    }
+    av[2] = tmp1;
+    av[3] = tmp2;
+    {
+      int i = 4;
+      if (proflag)
+        av[i++] = "-P";
+      if (Vflag)
+        av[i++] = "-V";
+      av[i] = 0;
+    }
 
-		if (callsys(pass0, av)) {
-			cflag++;
-			eflag++;
-			continue;
-		}
-		av[0] = "c1";
-		av[1] = tmp1;
-		av[2] = tmp2;
-		if (sflag) {
-			assource = tmp3 = setsuf(clist[i], 's');
-		}
-		av[3] = tmp3;
-		if (oflag)
-			av[3] = tmp5;
-		{
-			int i = 4;
-			if (Nflag)
-				av[i++] = "-N";
-			av[i] = 0;
-		}
+    if (debug_printout) {
+      k = 0;
+      while (av[k])
+        printf("%s ", av[k++]);
+      printf("\n");
+    }
 
-		if (debug_printout) {
-			k=0;
-			while (av[k])
-			    printf("%s ",av[k++]);
-			printf("\n");
-		}
+    if (callsys(pass0, av)) {
+      cflag++;
+      eflag++;
+      continue;
+    }
+    av[0] = "c1";
+    av[1] = tmp1;
+    av[2] = tmp2;
+    if (sflag) {
+      assource = tmp3 = setsuf(clist[i], 's');
+    }
+    av[3] = tmp3;
+    if (oflag)
+      av[3] = tmp5;
+    {
+      int i = 4;
+      if (Nflag)
+        av[i++] = "-N";
+      av[i] = 0;
+    }
 
-		if(callsys(pass1, av)) {
-			cflag++;
-			eflag++;
-			continue;
-		}
-		if (oflag) {
-			av[0] = "c2";
-			av[1] = tmp5;
-			av[2] = tmp3;
-			av[3] = 0;
+    if (debug_printout) {
+      k = 0;
+      while (av[k])
+        printf("%s ", av[k++]);
+      printf("\n");
+    }
 
-			if (debug_printout) {
-				k=0;
-				while (av[k])
-				    printf("%s ",av[k++]);
-				printf("\n");
-			}
+    if (callsys(pass1, av)) {
+      cflag++;
+      eflag++;
+      continue;
+    }
+    if (oflag) {
+      av[0] = "c2";
+      av[1] = tmp5;
+      av[2] = tmp3;
+      av[3] = 0;
 
-			if (callsys(pass2, av)) {
-				unlink(tmp3);
-				tmp3 = assource = tmp5;
-			}
-			else
-				unlink(tmp5);
-		}
-		if (sflag)
-			continue;
-assemble:
-		av[0] = "as";
-		av[1] = "-u";
-		av[2] = "-V";
-		av[3] = "-o";
-		av[4] = setsuf(clist[i], 'o');
-		av[5] = assource;
-		av[6] = 0;
-		cunlink(tmp1);
-		cunlink(tmp2);
-		cunlink(tmp4);
+      if (debug_printout) {
+        k = 0;
+        while (av[k])
+          printf("%s ", av[k++]);
+        printf("\n");
+      }
 
-		if (debug_printout) {
-			k=0;
-			while (av[k])
-			    printf("%s ",av[k++]);
-			printf("\n");
-		}
+      if (callsys(pass2, av)) {
+        unlink(tmp3);
+        tmp3 = assource = tmp5;
+      } else
+        unlink(tmp5);
+    }
+    if (sflag)
+      continue;
+  assemble:
+    av[0] = "as";
+    av[1] = "-u";
+    av[2] = "-V";
+    av[3] = "-o";
+    av[4] = setsuf(clist[i], 'o');
+    av[5] = assource;
+    av[6] = 0;
+    cunlink(tmp1);
+    cunlink(tmp2);
+    cunlink(tmp4);
 
-		if (callsys("/bin/as", av) > 1) {
-			cflag++;
-			eflag++;
-			continue;
-		}
-	}
+    if (debug_printout) {
+      k = 0;
+      while (av[k])
+        printf("%s ", av[k++]);
+      printf("\n");
+    }
+
+    if (callsys("/bin/as", av) > 1) {
+      cflag++;
+      eflag++;
+      continue;
+    }
+  }
 nocom:
-	if (cflag==0 && nl!=0) {
-		i = 0;
-		av[0] = "ld";
-		av[1] = "-X";
-		av[2] = pref;
-		j = 3;
-		if (noflflag) {
-			j = 4;
-			av[3] = "-lfpsim";
-		}
-		if (outfile) {
-			av[j++] = "-o";
-			av[j++] = outfile;
-		}
-		while(i<nl)
-			av[j++] = llist[i++];
-		if (!Vflag) {
-			av[j++] = "/lib/v7csv.o";
-		}
-		if(f20)
-			av[j++] = "-l2";
-		else {
-			if (sys_V_flag)		  /* System V environment */
-				av[j++] = "-lcV"; /* so load libcV.a first */
-			av[j++] = "-lc";
-		}
-		av[j++] = 0;
+  if (cflag == 0 && nl != 0) {
+    i = 0;
+    av[0] = "ld";
+    av[1] = "-X";
+    av[2] = pref;
+    j = 3;
+    if (noflflag) {
+      j = 4;
+      av[3] = "-lfpsim";
+    }
+    if (outfile) {
+      av[j++] = "-o";
+      av[j++] = outfile;
+    }
+    while (i < nl)
+      av[j++] = llist[i++];
+    if (!Vflag) {
+      av[j++] = "/lib/v7csv.o";
+    }
+    if (f20)
+      av[j++] = "-l2";
+    else {
+      if (sys_V_flag)     /* System V environment */
+        av[j++] = "-lcV"; /* so load libcV.a first */
+      av[j++] = "-lc";
+    }
+    av[j++] = 0;
 
-		if (debug_printout) {
-			k=0;
-			while (av[k])
-			    printf("%s ",av[k++]);
-			printf("\n");
-		}
+    if (debug_printout) {
+      k = 0;
+      while (av[k])
+        printf("%s ", av[k++]);
+      printf("\n");
+    }
 
-		eflag |= callsys("/bin/ld", av);
-		if (nc==1 && nxo==1 && eflag==0)
-			cunlink(setsuf(clist[0], 'o'));
-	}
-	dexit();
+    eflag |= callsys("/bin/ld", av);
+    if (nc == 1 && nxo == 1 && eflag == 0)
+      cunlink(setsuf(clist[0], 'o'));
+  }
+  dexit();
 }
 
-idexit()
+idexit() {
+  eflag = 100;
+  dexit();
+}
+
+dexit() {
+  if (!pflag) {
+    cunlink(tmp1);
+    cunlink(tmp2);
+    if (sflag == 0)
+      cunlink(tmp3);
+    cunlink(tmp4);
+    cunlink(tmp5);
+  }
+  exit(eflag);
+}
+
+error(s, x) char *s, *x;
 {
-	eflag = 100;
-	dexit();
+  fprintf(exflag ? stderr : stdout, s, x);
+  putc('\n', exflag ? stderr : stdout);
+  cflag++;
+  eflag++;
 }
 
-dexit()
+getsuf(as) char as[];
 {
-	if (!pflag) {
-		cunlink(tmp1);
-		cunlink(tmp2);
-		if (sflag==0)
-			cunlink(tmp3);
-		cunlink(tmp4);
-		cunlink(tmp5);
-	}
-	exit(eflag);
+  register int c;
+  register char *s;
+  register int t;
+
+  s = as;
+  c = 0;
+  while (t = *s++)
+    if (t == '/')
+      c = 0;
+    else
+      c++;
+  s -= 3;
+  if (c <= 14 && c > 2 && *s++ == '.')
+    return (*s);
+  return (0);
 }
 
-error(s, x)
-char *s, *x;
-{
-	fprintf(exflag?stderr:stdout, s, x);
-	putc('\n', exflag? stderr : stdout);
-	cflag++;
-	eflag++;
-}
-
-
-
-
-getsuf(as)
-char as[];
-{
-	register int c;
-	register char *s;
-	register int t;
-
-	s = as;
-	c = 0;
-	while(t = *s++)
-		if (t=='/')
-			c = 0;
-		else
-			c++;
-	s -= 3;
-	if (c<=14 && c>2 && *s++=='.')
-		return(*s);
-	return(0);
-}
-
-char *
-setsuf(as, ch)
+char *setsuf(as, ch)
 char *as;
 {
-	register char *s, *s1;
+  register char *s, *s1;
 
-	s = s1 = copy(as);
-	while(*s)
-		if (*s++ == '/')
-			s1 = s;
-	s[-1] = ch;
-	return(s1);
+  s = s1 = copy(as);
+  while (*s)
+    if (*s++ == '/')
+      s1 = s;
+  s[-1] = ch;
+  return (s1);
 }
 
-callsys(f, v)
-char f[], *v[];
+callsys(f, v) char f[], *v[];
 {
-	int t, status;
+  int t, status;
 
-	if ((t=fork())==0) {
-		execv(f, v);
-		printf("Can't find %s\n", f);
-		exit(100);
-	} else
-		if (t == -1) {
-			printf("Try again\n");
-			return(100);
-		}
-	while(t!=wait(&status))
-		;
-	if (t = status&0377) {
-		if (t!=SIGINT) {
-			printf("Fatal error in %s\n", f);
-			eflag = 8;
-		}
-		dexit();
-	}
-	return((status>>8) & 0377);
+  if ((t = fork()) == 0) {
+    execv(f, v);
+    printf("Can't find %s\n", f);
+    exit(100);
+  } else if (t == -1) {
+    printf("Try again\n");
+    return (100);
+  }
+  while (t != wait(&status))
+    ;
+  if (t = status & 0377) {
+    if (t != SIGINT) {
+      printf("Fatal error in %s\n", f);
+      eflag = 8;
+    }
+    dexit();
+  }
+  return ((status >> 8) & 0377);
 }
 
-char *
-copy(as)
+char *copy(as)
 char *as;
 {
-	char *malloc();
-	register char *otsp, *s;
+  char *malloc();
+  register char *otsp, *s;
 
-	otsp = tsp;
-	s = as;
-	while (*tsp++ = *s++)
-		;
-	if (tsp > tsa+CHSPACE) {
-		tsp = tsa = malloc(CHSPACE+50);
-		if (tsp==NULL) {
-			error("no space for file names", (char *)NULL);
-			dexit();
-		}
-	}
-	return(otsp);
+  otsp = tsp;
+  s = as;
+  while (*tsp++ = *s++)
+    ;
+  if (tsp > tsa + CHSPACE) {
+    tsp = tsa = malloc(CHSPACE + 50);
+    if (tsp == NULL) {
+      error("no space for file names", (char *)NULL);
+      dexit();
+    }
+  }
+  return (otsp);
 }
 
-nodup(l, os)
-char **l, *os;
+nodup(l, os) char **l, *os;
 {
-	register char *t, *s;
-	register int c;
+  register char *t, *s;
+  register int c;
 
-	s = os;
-	if (getsuf(s) != 'o')
-		return(1);
-	while(t = *l++) {
-		while(c = *s++)
-			if (c != *t++)
-				break;
-		if (*t=='\0' && c=='\0')
-			return(0);
-		s = os;
-	}
-	return(1);
+  s = os;
+  if (getsuf(s) != 'o')
+    return (1);
+  while (t = *l++) {
+    while (c = *s++)
+      if (c != *t++)
+        break;
+    if (*t == '\0' && c == '\0')
+      return (0);
+    s = os;
+  }
+  return (1);
 }
 
-cunlink(f)
-char *f;
+cunlink(f) char *f;
 {
-	if (f==NULL)
-		return;
-	unlink(f);
+  if (f == NULL)
+    return;
+  unlink(f);
 }

--- a/src/cmd/checkeq.c
+++ b/src/cmd/checkeq.c
@@ -4,104 +4,117 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file checkeq.c
+ * @brief Check troff input for errors.
+ */
 
 static char Sccsid[] = "@(#)checkeq.c 3.0 4/21/86";
 #include <stdio.h>
-FILE	*fin;
-int	delim	= 0;
+FILE *fin;
+int delim = 0;
 /* today's version assumes no delimiters;
 they must be explicitly set
 */
 
-main(argc, argv) char **argv; {
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv)
 
-	while (argc > 1 && argv[1][0] == '-') {
-		switch (argv[1][1]) {
-		case 'd':
-			delim = argv[1][2];
-			break;
-		}
-		argc--;
-		argv++;
-	}
-	if (argc <= 1)
-		check(stdin);
-	else
-		while (--argc > 0) {
-			if ((fin = fopen(*++argv, "r")) == NULL) {
-				printf("Can't open %s\n", *argv);
-				exit(1);
-			}
-			printf("%s:\n", *argv);
-			check(fin);
-			fclose(fin);
-		}
+    while (argc > 1 && argv[1][0] == '-') {
+  switch (argv[1][1]) {
+  case 'd':
+    delim = argv[1][2];
+    break;
+  }
+  argc--;
+  argv++;
+}
+if (argc <= 1)
+  check(stdin);
+else
+  while (--argc > 0) {
+    if ((fin = fopen(*++argv, "r")) == NULL) {
+      printf("Can't open %s\n", *argv);
+      exit(1);
+    }
+    printf("%s:\n", *argv);
+    check(fin);
+    fclose(fin);
+  }
 }
 
-check(f)
-FILE	*f;
+check(f) FILE *f;
 {
-	int start, line, eq, ndel, totdel;
-	char in[600], *p;
+  int start, line, eq, ndel, totdel;
+  char in[600], *p;
 
-	start = eq = line = ndel = totdel = 0;
-	while (fgets(in, 600, f) != NULL) {
-		line++;
-		ndel = 0;
-		for (p = in; *p; p++)
-			if (*p == delim)
-				ndel++;
-		if (*in=='.' && *(in+1)=='E' && *(in+2)=='Q') {
-			if (eq++)
-				printf("   Spurious EQ, line %d\n", line);
-			if (totdel)
-				printf("   EQ in %c%c, line %d\n", delim, delim, line);
-		} else if (*in=='.' && *(in+1)=='E' && *(in+2)=='N') {
-			if (eq==0)
-				printf("   Spurious EN, line %d\n", line);
-			else
-				eq = 0;
-			if (totdel > 0)
-				printf("   EN in %c%c, line %d\n", delim, delim, line);
-			start = 0;
-		} else if (eq && *in=='d' && *(in+1)=='e' && *(in+2)=='l' && *(in+3)=='i' && *(in+4)=='m') {
-			for (p=in+5; *p; p++)
-				if (*p != ' ') {
-					if (*p == 'o' && *(p+1) == 'f')
-						delim = 0;
-					else {
-						delim = *p;
-						ndel = totdel = 0;
-					}
-					break;
-				}
-			if (delim == 0)
-				printf("   Delim off, line %d\n", line);
-			else
-				printf("   New delims %c%c, line %d\n", delim, delim, line);
-		}
-		if (ndel > 0 && eq > 0)
-			printf("   %c%c in EQ, line %d\n", delim, delim, line);
-		if (ndel == 0)
-			continue;
-		totdel += ndel;
-		if (totdel%2) {
-			if (start == 0)
-				start = line;
-			else {
-				printf("   %d line %c%c, lines %d-%d\n", line-start+1, delim, delim, start, line);
-				start = line;
-			}
-		} else {
-			if (start > 0) {
-				printf("   %d line %c%c, lines %d-%d\n", line-start+1, delim, delim, start, line);
-				start = 0;
-			}
-			totdel = 0;
-		}
-	}
-	if (totdel)
-		printf("   Unfinished %c%c\n", delim, delim);
-	if (eq)
-		printf("   Unfinished EQ\n");
+  start = eq = line = ndel = totdel = 0;
+  while (fgets(in, 600, f) != NULL) {
+    line++;
+    ndel = 0;
+    for (p = in; *p; p++)
+      if (*p == delim)
+        ndel++;
+    if (*in == '.' && *(in + 1) == 'E' && *(in + 2) == 'Q') {
+      if (eq++)
+        printf("   Spurious EQ, line %d\n", line);
+      if (totdel)
+        printf("   EQ in %c%c, line %d\n", delim, delim, line);
+    } else if (*in == '.' && *(in + 1) == 'E' && *(in + 2) == 'N') {
+      if (eq == 0)
+        printf("   Spurious EN, line %d\n", line);
+      else
+        eq = 0;
+      if (totdel > 0)
+        printf("   EN in %c%c, line %d\n", delim, delim, line);
+      start = 0;
+    } else if (eq && *in == 'd' && *(in + 1) == 'e' && *(in + 2) == 'l' &&
+               *(in + 3) == 'i' && *(in + 4) == 'm') {
+      for (p = in + 5; *p; p++)
+        if (*p != ' ') {
+          if (*p == 'o' && *(p + 1) == 'f')
+            delim = 0;
+          else {
+            delim = *p;
+            ndel = totdel = 0;
+          }
+          break;
+        }
+      if (delim == 0)
+        printf("   Delim off, line %d\n", line);
+      else
+        printf("   New delims %c%c, line %d\n", delim, delim, line);
+    }
+    if (ndel > 0 && eq > 0)
+      printf("   %c%c in EQ, line %d\n", delim, delim, line);
+    if (ndel == 0)
+      continue;
+    totdel += ndel;
+    if (totdel % 2) {
+      if (start == 0)
+        start = line;
+      else {
+        printf("   %d line %c%c, lines %d-%d\n", line - start + 1, delim, delim,
+               start, line);
+        start = line;
+      }
+    } else {
+      if (start > 0) {
+        printf("   %d line %c%c, lines %d-%d\n", line - start + 1, delim, delim,
+               start, line);
+        start = 0;
+      }
+      totdel = 0;
+    }
+  }
+  if (totdel)
+    printf("   Unfinished %c%c\n", delim, delim);
+  if (eq)
+    printf("   Unfinished EQ\n");
 }

--- a/src/cmd/chgrp.c
+++ b/src/cmd/chgrp.c
@@ -4,62 +4,70 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file chgrp.c
+ * @brief Change group ownership.
+ */
 
 /*
  * chgrp gid file ...
  */
 
 static char Sccsid[] = "@(#)chgrp.c 3.0 4/21/86";
-#include <stdio.h>
 #include <ctype.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <grp.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
-struct	group	*gr,*getgrnam();
-struct	stat	stbuf;
-int	gid;
-int	status;
+struct group *gr, *getgrnam();
+struct stat stbuf;
+int gid;
+int status;
 
-main(argc, argv)
-char *argv[];
-{
-	register c;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  register c;
 
-	if(argc < 3) {
-		printf("usage: chgrp gid file ...\n");
-		exit(4);
-	}
-	if(isnumber(argv[1])) {
-		gid = atoi(argv[1]);
-	} else {
-		if((gr=getgrnam(argv[1])) == NULL) {
-			printf("unknown group: %s\n",argv[1]);
-			exit(4);
-		}
-		gid = gr->gr_gid;
-	}
-	for(c=2; c<argc; c++) {
-		stat(argv[c], &stbuf);
-		if(chown(argv[c], stbuf.st_uid, gid) < 0) {
-			perror(argv[c]);	
+  if (argc < 3) {
+    printf("usage: chgrp gid file ...\n");
+    exit(4);
+  }
+  if (isnumber(argv[1])) {
+    gid = atoi(argv[1]);
+  } else {
+    if ((gr = getgrnam(argv[1])) == NULL) {
+      printf("unknown group: %s\n", argv[1]);
+      exit(4);
+    }
+    gid = gr->gr_gid;
+  }
+  for (c = 2; c < argc; c++) {
+    stat(argv[c], &stbuf);
+    if (chown(argv[c], stbuf.st_uid, gid) < 0) {
+      perror(argv[c]);
 
-			/* SYSTEM V compatibility */
-			/* printf("%s: permission denied, must be super-user\n",
-				argv[c]); */
-			status = 1;
-		}
-	}
-	exit(status);
+      /* SYSTEM V compatibility */
+      /* printf("%s: permission denied, must be super-user\n",
+              argv[c]); */
+      status = 1;
+    }
+  }
+  exit(status);
 }
 
-isnumber(s)
-char *s;
+isnumber(s) char *s;
 {
-	register c;
+  register c;
 
-	while(c = *s++)
-		if(!isdigit(c))
-			return(0);
-	return(1);
+  while (c = *s++)
+    if (!isdigit(c))
+      return (0);
+  return (1);
 }

--- a/src/cmd/chmod.c
+++ b/src/cmd/chmod.c
@@ -4,6 +4,10 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file chmod.c
+ * @brief Change file modes.
+ */
 
 /*
  * chmod [ugoa][+-=][rwxstugo] files
@@ -11,175 +15,171 @@
  */
 static char Sccsid[] = "@(#)chmod.c 3.0 4/21/86";
 #include <stdio.h>
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
-#define	USER	05700	/* user's bits */
-#define	GROUP	02070	/* group's bits */
-#define	OTHER	00007	/* other's bits */
-#define	ALL	01777	/* all (note absence of setuid, etc) */
+#define USER 05700  /* user's bits */
+#define GROUP 02070 /* group's bits */
+#define OTHER 00007 /* other's bits */
+#define ALL 01777   /* all (note absence of setuid, etc) */
 
-#define	READ	00444	/* read permit */
-#define	WRITE	00222	/* write permit */
-#define	EXEC	00111	/* exec permit */
-#define	SETID	06000	/* set[ug]id */
-#define	STICKY	01000	/* sticky bit */
+#define READ 00444   /* read permit */
+#define WRITE 00222  /* write permit */
+#define EXEC 00111   /* exec permit */
+#define SETID 06000  /* set[ug]id */
+#define STICKY 01000 /* sticky bit */
 
-char	*ms;
-int	um;
-struct	stat st;
+char *ms;
+int um;
+struct stat st;
 
-main(argc,argv)
-char **argv;
+main(argc, argv) char **argv;
 {
-	register i;
-	register char *p;
-	int status = 0;
+  register i;
+  register char *p;
+  int status = 0;
 
-	if (argc < 3) {
-		fprintf(stderr, "Usage: chmod [ugoa][+-=][rwxstugo] file ...\n");
-		exit(255);
-	}
-	ms = argv[1];
-	um = umask(0);
-	newmode(0);
-	for (i = 2; i < argc; i++) {
-		p = argv[i];
-		if (stat(p, &st) < 0) {
-			fprintf(stderr, "chmod: can't access %s\n", p);
-			++status;
-			continue;
-		}
-		ms = argv[1];
-		if (chmod(p, newmode(st.st_mode)) < 0) {
-			fprintf(stderr, "chmod: can't change %s\n", p);
-			++status;
-			continue;
-		}
-	}
-	exit(status);
+  if (argc < 3) {
+    fprintf(stderr, "Usage: chmod [ugoa][+-=][rwxstugo] file ...\n");
+    exit(255);
+  }
+  ms = argv[1];
+  um = umask(0);
+  newmode(0);
+  for (i = 2; i < argc; i++) {
+    p = argv[i];
+    if (stat(p, &st) < 0) {
+      fprintf(stderr, "chmod: can't access %s\n", p);
+      ++status;
+      continue;
+    }
+    ms = argv[1];
+    if (chmod(p, newmode(st.st_mode)) < 0) {
+      fprintf(stderr, "chmod: can't change %s\n", p);
+      ++status;
+      continue;
+    }
+  }
+  exit(status);
 }
 
-newmode(nm)
-unsigned nm;
+newmode(nm) unsigned nm;
 {
-	register o, m, b;
+  register o, m, b;
 
-	m = abs();
-	if (!*ms)
-		return(m);
-	do {
-		m = who();
-		while (o = what()) {
-			b = where(nm);
-			switch (o) {
-			case '+':
-				nm |= b & m;
-				break;
-			case '-':
-				nm &= ~(b & m);
-				break;
-			case '=':
-				nm &= ~m;
-				nm |= b & m;
-				break;
-			}
-		}
-	} while (*ms++ == ',');
-	if (*--ms) {
-		fprintf(stderr, "chmod: invalid mode\n");
-		exit(255);
-	}
-	return(nm);
+  m = abs();
+  if (!*ms)
+    return (m);
+  do {
+    m = who();
+    while (o = what()) {
+      b = where(nm);
+      switch (o) {
+      case '+':
+        nm |= b & m;
+        break;
+      case '-':
+        nm &= ~(b & m);
+        break;
+      case '=':
+        nm &= ~m;
+        nm |= b & m;
+        break;
+      }
+    }
+  } while (*ms++ == ',');
+  if (*--ms) {
+    fprintf(stderr, "chmod: invalid mode\n");
+    exit(255);
+  }
+  return (nm);
 }
 
-abs()
-{
-	register c, i;
+abs() {
+  register c, i;
 
-	i = 0;
-	while ((c = *ms++) >= '0' && c <= '7')
-		i = (i << 3) + (c - '0');
-	ms--;
-	return(i);
+  i = 0;
+  while ((c = *ms++) >= '0' && c <= '7')
+    i = (i << 3) + (c - '0');
+  ms--;
+  return (i);
 }
 
-who()
-{
-	register m;
+who() {
+  register m;
 
-	m = 0;
-	for (;;) switch (*ms++) {
-	case 'u':
-		m |= USER;
-		continue;
-	case 'g':
-		m |= GROUP;
-		continue;
-	case 'o':
-		m |= OTHER;
-		continue;
-	case 'a':
-		m |= ALL;
-		continue;
-	default:
-		ms--;
-		if (m == 0)
-			m = ALL & ~um;
-		return m;
-	}
+  m = 0;
+  for (;;)
+    switch (*ms++) {
+    case 'u':
+      m |= USER;
+      continue;
+    case 'g':
+      m |= GROUP;
+      continue;
+    case 'o':
+      m |= OTHER;
+      continue;
+    case 'a':
+      m |= ALL;
+      continue;
+    default:
+      ms--;
+      if (m == 0)
+        m = ALL & ~um;
+      return m;
+    }
 }
 
-what()
-{
-	switch (*ms) {
-	case '+':
-	case '-':
-	case '=':
-		return *ms++;
-	}
-	return(0);
+what() {
+  switch (*ms) {
+  case '+':
+  case '-':
+  case '=':
+    return *ms++;
+  }
+  return (0);
 }
 
-where(om)
-register om;
+where(om) register om;
 {
-	register m;
+  register m;
 
-	m = 0;
-	switch (*ms) {
-	case 'u':
-		m = (om & USER) >> 6;
-		goto dup;
-	case 'g':
-		m = (om & GROUP) >> 3;
-		goto dup;
-	case 'o':
-		m = (om & OTHER);
-	dup:
-		m &= (READ|WRITE|EXEC);
-		m |= (m << 3) | (m << 6);
-		++ms;
-		return m;
-	}
-	for (;;) switch (*ms++) {
-	case 'r':
-		m |= READ;
-		continue;
-	case 'w':
-		m |= WRITE;
-		continue;
-	case 'x':
-		m |= EXEC;
-		continue;
-	case 's':
-		m |= SETID;
-		continue;
-	case 't':
-		m |= STICKY;
-		continue;
-	default:
-		ms--;
-		return m;
-	}
+  m = 0;
+  switch (*ms) {
+  case 'u':
+    m = (om & USER) >> 6;
+    goto dup;
+  case 'g':
+    m = (om & GROUP) >> 3;
+    goto dup;
+  case 'o':
+    m = (om & OTHER);
+  dup:
+    m &= (READ | WRITE | EXEC);
+    m |= (m << 3) | (m << 6);
+    ++ms;
+    return m;
+  }
+  for (;;)
+    switch (*ms++) {
+    case 'r':
+      m |= READ;
+      continue;
+    case 'w':
+      m |= WRITE;
+      continue;
+    case 'x':
+      m |= EXEC;
+      continue;
+    case 's':
+      m |= SETID;
+      continue;
+    case 't':
+      m |= STICKY;
+      continue;
+    default:
+      ms--;
+      return m;
+    }
 }

--- a/src/cmd/chog.c
+++ b/src/cmd/chog.c
@@ -4,7 +4,10 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
-
+/**
+ * @file chog.c
+ * @brief Change file owner and group.
+ */
 
 /*
  * Chog: CHange Owner and Group
@@ -13,50 +16,54 @@
 
 static char Sccsid[] = "@(#)chog.c	3.0	4/21/86";
 
-#include <stdio.h>
 #include <ctype.h>
-#include <sys/types.h>
 #include <pwd.h>
+#include <stdio.h>
+#include <sys/types.h>
 
-
-main(argc, argv)
-int	argc;
-char	*argv[];
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) int argc;
 {
-	int	uid, gid;
-	int	status = 0;
-	struct	passwd	*pwd, *getpwnam(), *getpwuid();
+  int uid, gid;
+  int status = 0;
+  struct passwd *pwd, *getpwnam(), *getpwuid();
 
-	if(argc < 3) {
-		printf("usage: chog user file ...\n");
-		exit(1);
-	}
-	--argc; ++argv;
-	if (isnumber(*argv)) {
-		uid = atoi(*argv);
-		pwd = getpwuid(uid);
-	} else
-		pwd = getpwnam(*argv);
-	if (pwd == NULL) {
-		printf("unknown user id: %s\n", *argv);
-		exit(1);
-	}
-	uid = pwd->pw_uid;
-	gid = pwd->pw_gid;
+  if (argc < 3) {
+    printf("usage: chog user file ...\n");
+    exit(1);
+  }
+  --argc;
+  ++argv;
+  if (isnumber(*argv)) {
+    uid = atoi(*argv);
+    pwd = getpwuid(uid);
+  } else
+    pwd = getpwnam(*argv);
+  if (pwd == NULL) {
+    printf("unknown user id: %s\n", *argv);
+    exit(1);
+  }
+  uid = pwd->pw_uid;
+  gid = pwd->pw_gid;
 
-	while (++argv,--argc) {
-		if(chown(*argv, uid, gid) < 0) {
-			perror(*argv);
-			status = 1;
-		}
-	}
-	exit(status);
+  while (++argv, --argc) {
+    if (chown(*argv, uid, gid) < 0) {
+      perror(*argv);
+      status = 1;
+    }
+  }
+  exit(status);
 }
 
-isnumber(s)
-register char *s;
+isnumber(s) register char *s;
 {
-	while (isdigit(*s))
-		s++;
-	return((*s == '\0') ? 1 : 0);
+  while (isdigit(*s))
+    s++;
+  return ((*s == '\0') ? 1 : 0);
 }

--- a/src/cmd/chown.c
+++ b/src/cmd/chown.c
@@ -4,64 +4,72 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file chown.c
+ * @brief Change file owner.
+ */
 
 /*
  * chown uid file ...
  */
 
 static char Sccsid[] = "@(#)chown.c 3.0 4/21/86";
-#include <stdio.h>
 #include <ctype.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <pwd.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
-struct	passwd	*pwd,*getpwnam();
-struct	stat	stbuf;
-int	uid;
-int	status;
+struct passwd *pwd, *getpwnam();
+struct stat stbuf;
+int uid;
+int status;
 
-main(argc, argv)
-char *argv[];
-{
-	register c;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  register c;
 
-	if(argc < 3) {
-		printf("usage: chown uid file ...\n");
-		exit(4);
-	}
-	if(isnumber(argv[1])) {
-		uid = atoi(argv[1]);
-		goto cho;
-	}
-	if((pwd=getpwnam(argv[1])) == NULL) {
-		printf("unknown user id: %s\n",argv[1]);
-		exit(4);
-	}
-	uid = pwd->pw_uid;
+  if (argc < 3) {
+    printf("usage: chown uid file ...\n");
+    exit(4);
+  }
+  if (isnumber(argv[1])) {
+    uid = atoi(argv[1]);
+    goto cho;
+  }
+  if ((pwd = getpwnam(argv[1])) == NULL) {
+    printf("unknown user id: %s\n", argv[1]);
+    exit(4);
+  }
+  uid = pwd->pw_uid;
 
 cho:
-	for(c=2; c<argc; c++) {
-		stat(argv[c], &stbuf);
-		if(chown(argv[c], uid, stbuf.st_gid) < 0) {
-			perror(argv[c]);	
+  for (c = 2; c < argc; c++) {
+    stat(argv[c], &stbuf);
+    if (chown(argv[c], uid, stbuf.st_gid) < 0) {
+      perror(argv[c]);
 
-			/* SYSTEM V compatibility */
-			/* printf("%s: permission denied, must be super-user\n", 
-				argv[c]); */
-			status = 1;
-		}
-	}
-	exit(status);
+      /* SYSTEM V compatibility */
+      /* printf("%s: permission denied, must be super-user\n",
+              argv[c]); */
+      status = 1;
+    }
+  }
+  exit(status);
 }
 
-isnumber(s)
-char *s;
+isnumber(s) char *s;
 {
-	register c;
+  register c;
 
-	while(c = *s++)
-		if(!isdigit(c))
-			return(0);
-	return(1);
+  while (c = *s++)
+    if (!isdigit(c))
+      return (0);
+  return (1);
 }

--- a/src/cmd/chroot.c
+++ b/src/cmd/chroot.c
@@ -4,6 +4,10 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file chroot.c
+ * @brief Change root directory.
+ */
 
 /*
  * Chroot - CHange ROOT directory
@@ -20,45 +24,43 @@ char prompt[] = "PS1=(subroot)-> ";
 char *shell;
 char **newenv;
 
-main(argc, argv, envp)
-int argc;
-char *argv[], *envp[];
+main(argc, argv, envp) int argc;
 {
-	char *sbrk();
+  char *sbrk();
 
-	if (argc > 2) {
-		fprintf(stderr, "Usage: chroot [directory]\n");
-		exit(1);
-	} else if (argc == 2)
-		newroot = *++argv;
-	if ((chdir(newroot) == -1)
-	    || (chroot((*newroot == '/') ? newroot : ".") == -1)) {
-		perror(newroot);
-		exit(1);
-	}
-	newenv = envp;
-	while (*envp) {
-		if (strncmp(*envp, "PS1=", 4) == 0) {
-			*envp = prompt;
-			break;
-		}
-		++envp;
-	}
-	if (!*envp) {	/* PS1 wasn't in the enviornment, need to add it */
-		char **tp, **i = envp - newenv + 2;
-		envp = newenv;
-		tp = (char **)sbrk((int)i * sizeof(char **));
-		if (tp > 0) { /* we have the space */
-			newenv = tp;
-			*tp++ = prompt;
-			while (*tp++ = *envp++)
-				;
-		} else
-			fprintf(stderr,"Couldn't change prompt...\n");
-	}
-	if ((shell = getenv("SHELL")) == NULL)
-		shell = "/bin/sh";
-	execle(shell, "-sh", 0, newenv);
-	perror(shell);
-	exit(1);
+  if (argc > 2) {
+    fprintf(stderr, "Usage: chroot [directory]\n");
+    exit(1);
+  } else if (argc == 2)
+    newroot = *++argv;
+  if ((chdir(newroot) == -1) ||
+      (chroot((*newroot == '/') ? newroot : ".") == -1)) {
+    perror(newroot);
+    exit(1);
+  }
+  newenv = envp;
+  while (*envp) {
+    if (strncmp(*envp, "PS1=", 4) == 0) {
+      *envp = prompt;
+      break;
+    }
+    ++envp;
+  }
+  if (!*envp) { /* PS1 wasn't in the enviornment, need to add it */
+    char **tp, **i = envp - newenv + 2;
+    envp = newenv;
+    tp = (char **)sbrk((int)i * sizeof(char **));
+    if (tp > 0) { /* we have the space */
+      newenv = tp;
+      *tp++ = prompt;
+      while (*tp++ = *envp++)
+        ;
+    } else
+      fprintf(stderr, "Couldn't change prompt...\n");
+  }
+  if ((shell = getenv("SHELL")) == NULL)
+    shell = "/bin/sh";
+  execle(shell, "-sh", 0, newenv);
+  perror(shell);
+  exit(1);
 }

--- a/src/cmd/clear.c
+++ b/src/cmd/clear.c
@@ -4,6 +4,10 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file clear.c
+ * @brief Clear the screen.
+ */
 
 /* load me with -ltermlib */
 /*
@@ -11,39 +15,38 @@
  */
 
 static char Sccsid[] = "@(#)clear.c 3.0 4/21/86";
-#include <stdio.h>
 #include <sgtty.h>
+#include <stdio.h>
 
-char	*getenv();
-char	*tgetstr();
-char	PC;
-short	ospeed;
-#undef	putchar
-int	putchar();
+char *getenv();
+char *tgetstr();
+char PC;
+short ospeed;
+#undef putchar
+int putchar();
 
-main()
-{
-	char *cp = getenv("TERM");
-	char clbuf[20];
-	char pcbuf[20];
-	char *clbp = clbuf;
-	char *pcbp = pcbuf;
-	char *clear;
-	char buf[1024];
-	char *pc;
-	struct sgttyb tty;
+main() {
+  char *cp = getenv("TERM");
+  char clbuf[20];
+  char pcbuf[20];
+  char *clbp = clbuf;
+  char *pcbp = pcbuf;
+  char *clear;
+  char buf[1024];
+  char *pc;
+  struct sgttyb tty;
 
-	gtty(1, &tty);
-	ospeed = tty.sg_ospeed;
-	if (cp == (char *) 0)
-		exit(1);
-	if (tgetent(buf, cp) != 1)
-		exit(1);
-	pc = tgetstr("pc", &pcbp);
-	if (pc)
-		PC = *pc;
-	clear = tgetstr("cl", &clbp);
-	if (clear)
-		tputs(clear, tgetnum("li"), putchar);
-	exit (clear != (char *) 0);
+  gtty(1, &tty);
+  ospeed = tty.sg_ospeed;
+  if (cp == (char *)0)
+    exit(1);
+  if (tgetent(buf, cp) != 1)
+    exit(1);
+  pc = tgetstr("pc", &pcbp);
+  if (pc)
+    PC = *pc;
+  clear = tgetstr("cl", &clbp);
+  if (clear)
+    tputs(clear, tgetnum("li"), putchar);
+  exit(clear != (char *)0);
 }

--- a/src/cmd/clri.c
+++ b/src/cmd/clri.c
@@ -4,102 +4,109 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file clri.c
+ * @brief Clear inode.
+ */
 
 /*
  * clri filsys inumber ...
  */
 
 static char Sccsid[] = "@(#)clri.c 3.0 4/21/86";
-#ifdef	UCB_NKB
+#ifdef UCB_NKB
 #include <sys/param.h>
 #else
 #include <sys/types.h>
-#endif	UCB_NKB
+#endif UCB_NKB
 #include <sys/ino.h>
-#define ISIZE	(sizeof(struct dinode))
-#ifndef	UCB_NKB
-#define	BSIZE	512
-#endif	UCB_NKB
-#define	NI	(BSIZE/ISIZE)
-struct	ino
-{
-	char	junk[ISIZE];
+#define ISIZE (sizeof(struct dinode))
+#ifndef UCB_NKB
+#define BSIZE 512
+#endif UCB_NKB
+#define NI (BSIZE / ISIZE)
+struct ino {
+  char junk[ISIZE];
 };
-struct	ino	buf[NI];
-int	status;
+struct ino buf[NI];
+int status;
 
-main(argc, argv)
-char *argv[];
-{
-	register i, f;
-	unsigned n;
-	int j, k;
-	long off;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  register i, f;
+  unsigned n;
+  int j, k;
+  long off;
 
-	if(argc < 3) {
-		printf("usage: clri filsys inumber ...\n");
-		exit(4);
-	}
-	f = open(argv[1], 2);
-	if(f < 0) {
-		printf("cannot open %s\n", argv[1]);
-		exit(4);
-	}
-	for(i=2; i<argc; i++) {
-		if(!isnumber(argv[i])) {
-			printf("%s: is not a number\n", argv[i]);
-			status = 1;
-			continue;
-		}
-		n = atoi(argv[i]);
-		if(n == 0) {
-			printf("%s: is zero\n", argv[i]);
-			status = 1;
-			continue;
-		}
-#ifdef	UCB_NKB
-		off = itod(n) * BSIZE;
+  if (argc < 3) {
+    printf("usage: clri filsys inumber ...\n");
+    exit(4);
+  }
+  f = open(argv[1], 2);
+  if (f < 0) {
+    printf("cannot open %s\n", argv[1]);
+    exit(4);
+  }
+  for (i = 2; i < argc; i++) {
+    if (!isnumber(argv[i])) {
+      printf("%s: is not a number\n", argv[i]);
+      status = 1;
+      continue;
+    }
+    n = atoi(argv[i]);
+    if (n == 0) {
+      printf("%s: is zero\n", argv[i]);
+      status = 1;
+      continue;
+    }
+#ifdef UCB_NKB
+    off = itod(n) * BSIZE;
 #else
-		off = ((n-1)/NI + 2) * (long)512;
-#endif	UCB_NKB
-		lseek(f, off, 0);
-		if(read(f, (char *)buf, BSIZE) != BSIZE) {
-			printf("%s: read error\n", argv[i]);
-			status = 1;
-		}
-	}
-	if(status)
-		exit(status);
-	for(i=2; i<argc; i++) {
-		n = atoi(argv[i]);
-		printf("clearing %u\n", n);
-#ifdef	UCB_NKB
-		off = itod(n) * BSIZE;
+    off = ((n - 1) / NI + 2) * (long)512;
+#endif UCB_NKB
+    lseek(f, off, 0);
+    if (read(f, (char *)buf, BSIZE) != BSIZE) {
+      printf("%s: read error\n", argv[i]);
+      status = 1;
+    }
+  }
+  if (status)
+    exit(status);
+  for (i = 2; i < argc; i++) {
+    n = atoi(argv[i]);
+    printf("clearing %u\n", n);
+#ifdef UCB_NKB
+    off = itod(n) * BSIZE;
 #else
-		off = ((n-1)/NI + 2) * (long)512;
-#endif	UCB_NKB
-		lseek(f, off, 0);
-		read(f, (char *)buf, BSIZE);
-#ifdef	UCB_NKB
-		j = itoo(n);
+    off = ((n - 1) / NI + 2) * (long)512;
+#endif UCB_NKB
+    lseek(f, off, 0);
+    read(f, (char *)buf, BSIZE);
+#ifdef UCB_NKB
+    j = itoo(n);
 #else
-		j = (n-1)%NI;
-#endif	UCB_NKB
-		for(k=0; k<ISIZE; k++)
-			buf[j].junk[k] = 0;
-		lseek(f, off, 0);
-		write(f, (char *)buf, BSIZE);
-	}
-	exit(status);
+    j = (n - 1) % NI;
+#endif UCB_NKB
+    for (k = 0; k < ISIZE; k++)
+      buf[j].junk[k] = 0;
+    lseek(f, off, 0);
+    write(f, (char *)buf, BSIZE);
+  }
+  exit(status);
 }
 
-isnumber(s)
-char *s;
+isnumber(s) char *s;
 {
-	register c;
+  register c;
 
-	while(c = *s++)
-		if(c < '0' || c > '9')
-			return(0);
-	return(1);
+  while (c = *s++)
+    if (c < '0' || c > '9')
+      return (0);
+  return (1);
 }

--- a/src/cmd/cmp.c
+++ b/src/cmd/cmp.c
@@ -4,126 +4,134 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file cmp.c
+ * @brief Compare two files.
+ */
 
 static char Sccsid[] = "@(#)cmp.c 3.0 4/21/86";
-#include <stdio.h>
 #include <ctype.h>
+#include <stdio.h>
 
-FILE	*file1,*file2;
-int	eflg;
-int	lflg	= 1;
-long	line	= 1;
-long	chr	= 0;
-long	skip1;
-long	skip2;
+FILE *file1, *file2;
+int eflg;
+int lflg = 1;
+long line = 1;
+long chr = 0;
+long skip1;
+long skip2;
 
-long	otoi();
+long otoi();
 
-main(argc, argv)
-char **argv;
-{
-	register c1, c2;
-	char *arg;
+/**
+ * @brief Program entry point.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @return EXIT_SUCCESS on success.
+ */
+int main(int argc, char **argv) {
+  register c1, c2;
+  char *arg;
 
-	if(argc < 3)
-		goto narg;
-	arg = argv[1];
-	if(arg[0] == '-' && arg[1] == 's') {
-		lflg--;
-		argv++;
-		argc--;
-	}
-	arg = argv[1];
-	if(arg[0] == '-' && arg[1] == 'l') {
-		lflg++;
-		argv++;
-		argc--;
-	}
-	if(argc < 3)
-		goto narg;
-	arg = argv[1];
-	if( arg[0]=='-' && arg[1]==0 )
-		file1 = stdin;
-	else if((file1 = fopen(arg, "r")) == NULL)
-		goto barg;
-	arg = argv[2];
-	if((file2 = fopen(arg, "r")) == NULL)
-		goto barg;
-	if (argc>3)
-		skip1 = otoi(argv[3]);
-	if (argc>4)
-		skip2 = otoi(argv[4]);
-	while (skip1) {
-		if ((c1 = getc(file1)) == EOF) {
-			arg = argv[1];
-			goto earg;
-		}
-		skip1--;
-	}
-	while (skip2) {
-		if ((c2 = getc(file2)) == EOF) {
-			arg = argv[2];
-			goto earg;
-		}
-		skip2--;
-	}
+  if (argc < 3)
+    goto narg;
+  arg = argv[1];
+  if (arg[0] == '-' && arg[1] == 's') {
+    lflg--;
+    argv++;
+    argc--;
+  }
+  arg = argv[1];
+  if (arg[0] == '-' && arg[1] == 'l') {
+    lflg++;
+    argv++;
+    argc--;
+  }
+  if (argc < 3)
+    goto narg;
+  arg = argv[1];
+  if (arg[0] == '-' && arg[1] == 0)
+    file1 = stdin;
+  else if ((file1 = fopen(arg, "r")) == NULL)
+    goto barg;
+  arg = argv[2];
+  if ((file2 = fopen(arg, "r")) == NULL)
+    goto barg;
+  if (argc > 3)
+    skip1 = otoi(argv[3]);
+  if (argc > 4)
+    skip2 = otoi(argv[4]);
+  while (skip1) {
+    if ((c1 = getc(file1)) == EOF) {
+      arg = argv[1];
+      goto earg;
+    }
+    skip1--;
+  }
+  while (skip2) {
+    if ((c2 = getc(file2)) == EOF) {
+      arg = argv[2];
+      goto earg;
+    }
+    skip2--;
+  }
 
 loop:
-	chr++;
-	c1 = getc(file1);
-	c2 = getc(file2);
-	if(c1 == c2) {
-		if (c1 == '\n')
-			line++;
-		if(c1 == EOF) {
-			if(eflg)
-				exit(1);
-			exit(0);
-		}
-		goto loop;
-	}
-	if(lflg == 0)
-		exit(1);
-	if(c1 == EOF) {
-		arg = argv[1];
-		goto earg;
-	}
-	if(c2 == EOF)
-		goto earg;
-	if(lflg == 1) {
-		printf("%s %s differ: char %ld, line %ld\n", argv[1], arg,
-			chr, line);
-		exit(1);
-	}
-	eflg = 1;
-	printf("%6ld %3o %3o\n", chr, c1, c2);
-	goto loop;
+  chr++;
+  c1 = getc(file1);
+  c2 = getc(file2);
+  if (c1 == c2) {
+    if (c1 == '\n')
+      line++;
+    if (c1 == EOF) {
+      if (eflg)
+        exit(1);
+      exit(0);
+    }
+    goto loop;
+  }
+  if (lflg == 0)
+    exit(1);
+  if (c1 == EOF) {
+    arg = argv[1];
+    goto earg;
+  }
+  if (c2 == EOF)
+    goto earg;
+  if (lflg == 1) {
+    printf("%s %s differ: char %ld, line %ld\n", argv[1], arg, chr, line);
+    exit(1);
+  }
+  eflg = 1;
+  printf("%6ld %3o %3o\n", chr, c1, c2);
+  goto loop;
 
 narg:
-	printf("cmp: arg count\n");
-	exit(2);
+  printf("cmp: arg count\n");
+  exit(2);
 
 barg:
-	if (lflg)
-	printf("cmp: cannot open %s\n", arg);
-	exit(2);
+  if (lflg)
+    printf("cmp: cannot open %s\n", arg);
+  exit(2);
 
 earg:
-	printf("cmp: EOF on %s\n", arg);
-	exit(1);
+  printf("cmp: EOF on %s\n", arg);
+  exit(1);
 }
 
 long otoi(s)
 char *s;
 {
-	long v;
-	int base;
+  long v;
+  int base;
 
-	v = 0;
-	base = 10;
-	if (*s == '0')
-		base = 8;
-	while(isdigit(*s))
-		v = v*base + *s++ - '0';
-	return(v);
+  v = 0;
+  base = 10;
+  if (*s == '0')
+    base = 8;
+  while (isdigit(*s))
+    v = v * base + *s++ - '0';
+  return (v);
 }

--- a/src/cmd/col.c
+++ b/src/cmd/col.c
@@ -4,20 +4,24 @@
  *   All Rights Reserved. 					      *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
+/**
+ * @file col.c
+ * @brief Filter reverse line feeds.
+ */
 
 static char Sccsid[] = "@(#)col.c 3.0 4/21/86";
-# include <stdio.h>
+#include <stdio.h>
 
-# define PL 256
-# define ESC '\033'
-# define RLF '\013'
-# define SI '\017'
-# define SO '\016'
-# define GREEK 0200
-# define LINELN 800
+#define PL 256
+#define ESC '\033'
+#define RLF '\013'
+#define SI '\017'
+#define SO '\016'
+#define GREEK 0200
+#define LINELN 800
 
 char *page[PL];
-char lbuff [LINELN], *line;
+char lbuff[LINELN], *line;
 int bflag, xflag, fflag;
 int half;
 int cp, lp;
@@ -26,297 +30,288 @@ int pcp = 0;
 char *pgmname;
 char *strcpy();
 
-main (argc, argv)
-	int argc; char **argv;
+main(argc, argv) int argc;
 {
-	int i;
-	int greek;
-	register int c;
-	char fbuff[BUFSIZ];
+  int i;
+  int greek;
+  register int c;
+  char fbuff[BUFSIZ];
 
-	setbuf (stdout, fbuff);
-	pgmname = argv[0];
+  setbuf(stdout, fbuff);
+  pgmname = argv[0];
 
-	for (i = 1; i < argc; i++) {
-		register char *p;
-		if (*argv[i] != '-') {
-			fprintf (stderr, "%s: bad option %s\n",
-				pgmname, argv[i]);
-			exit (2);
-		}
-		for (p = argv[i]+1; *p; p++) {
-			switch (*p) {
-			case 'b':
-				bflag++;
-				break;
+  for (i = 1; i < argc; i++) {
+    register char *p;
+    if (*argv[i] != '-') {
+      fprintf(stderr, "%s: bad option %s\n", pgmname, argv[i]);
+      exit(2);
+    }
+    for (p = argv[i] + 1; *p; p++) {
+      switch (*p) {
+      case 'b':
+        bflag++;
+        break;
 
-			case 'x':
-				xflag++;
-				break;
+      case 'x':
+        xflag++;
+        break;
 
-			case 'f':
-				fflag++;
-				break;
+      case 'f':
+        fflag++;
+        break;
 
-			default:
-				fprintf (stderr, "%s: bad option letter %c\n",
-					pgmname, *p);
-				exit (2);
-			}
-		}
-	}
+      default:
+        fprintf(stderr, "%s: bad option letter %c\n", pgmname, *p);
+        exit(2);
+      }
+    }
+  }
 
-	for (ll=0; ll<PL; ll++)
-		page[ll] = 0;
+  for (ll = 0; ll < PL; ll++)
+    page[ll] = 0;
 
-	cp = 0;
-	ll = 0;
-	greek = 0;
-	mustwr = PL;
-	line = lbuff;
+  cp = 0;
+  ll = 0;
+  greek = 0;
+  mustwr = PL;
+  line = lbuff;
 
-	while ((c = getchar()) != EOF) {
-		switch (c) {
-		case '\n':
-			incr();
-			incr();
-			cp = 0;
-			continue;
+  while ((c = getchar()) != EOF) {
+    switch (c) {
+    case '\n':
+      incr();
+      incr();
+      cp = 0;
+      continue;
 
-		case '\0':
-			continue;
+    case '\0':
+      continue;
 
-		case ESC:
-			c = getchar();
-			switch (c) {
-			case '7':	/* reverse full line feed */
-				decr();
-				decr();
-				break;
+    case ESC:
+      c = getchar();
+      switch (c) {
+      case '7': /* reverse full line feed */
+        decr();
+        decr();
+        break;
 
-			case '8':	/* reverse half line feed */
-				if (fflag)
-					decr();
-				else {
-					if (--half < -1) {
-						decr();
-						decr();
-						half += 2;
-					}
-				}
-				break;
+      case '8': /* reverse half line feed */
+        if (fflag)
+          decr();
+        else {
+          if (--half < -1) {
+            decr();
+            decr();
+            half += 2;
+          }
+        }
+        break;
 
-			case '9':	/* forward half line feed */
-				if (fflag)
-					incr();
-				else {
-					if (++half > 0) {
-						incr();
-						incr();
-						half -= 2;
-					}
-				}
-				break;
-			}
-			continue;
+      case '9': /* forward half line feed */
+        if (fflag)
+          incr();
+        else {
+          if (++half > 0) {
+            incr();
+            incr();
+            half -= 2;
+          }
+        }
+        break;
+      }
+      continue;
 
-		case SO:
-			greek = GREEK;
-			continue;
+    case SO:
+      greek = GREEK;
+      continue;
 
-		case SI:
-			greek = 0;
-			continue;
+    case SI:
+      greek = 0;
+      continue;
 
-		case RLF:
-			decr();
-			decr();
-			continue;
+    case RLF:
+      decr();
+      decr();
+      continue;
 
-		case '\r':
-			cp = 0;
-			continue;
+    case '\r':
+      cp = 0;
+      continue;
 
-		case '\t':
-			cp = (cp + 8) & -8;
-			continue;
+    case '\t':
+      cp = (cp + 8) & -8;
+      continue;
 
-		case '\b':
-			if (cp > 0)
-				cp--;
-			continue;
+    case '\b':
+      if (cp > 0)
+        cp--;
+      continue;
 
-		case ' ':
-			cp++;
-			continue;
+    case ' ':
+      cp++;
+      continue;
 
-		default:
-			c &= 0177;
-			if (c > 040 && c < 0177) {	/* if printable */
-				outc(c | greek);
-				cp++;
-			}
-			continue;
-		}
-	}
+    default:
+      c &= 0177;
+      if (c > 040 && c < 0177) { /* if printable */
+        outc(c | greek);
+        cp++;
+      }
+      continue;
+    }
+  }
 
-	for (i=0; i<PL; i++)
-		if (page[(mustwr+i)%PL] != 0)
-			emit (page[(mustwr+i) % PL], mustwr+i-PL);
-	emit (" ", (llh + 1) & -2);
-	return 0;
+  for (i = 0; i < PL; i++)
+    if (page[(mustwr + i) % PL] != 0)
+      emit(page[(mustwr + i) % PL], mustwr + i - PL);
+  emit(" ", (llh + 1) & -2);
+  return 0;
 }
 
-outc (c)
-	register char c;
+outc(c) register char c;
 {
-	if (lp > cp) {
-		line = lbuff;
-		lp = 0;
-	}
+  if (lp > cp) {
+    line = lbuff;
+    lp = 0;
+  }
 
-	while (lp < cp) {
-		switch (*line) {
-		case '\0':
-			*line = ' ';
-			lp++;
-			break;
+  while (lp < cp) {
+    switch (*line) {
+    case '\0':
+      *line = ' ';
+      lp++;
+      break;
 
-		case '\b':
-			lp--;
-			break;
+    case '\b':
+      lp--;
+      break;
 
-		default:
-			lp++;
-		}
-		line++;
-	}
-	while (*line == '\b') {
-		line += 2;
-	}
-	if (bflag || *line == '\0' || *line == ' ')
-		*line = c;
-	else {
-		register char c1, c2, c3;
-		c1 = *++line;
-		*line++ = '\b';
-		c2 = *line;
-		*line++ = c;
-		while (c1) {
-			c3 = *line;
-			*line++ = c1;
-			c1 = c2;
-			c2 = c3;
-		}
-		lp = 0;
-		line = lbuff;
-	}
+    default:
+      lp++;
+    }
+    line++;
+  }
+  while (*line == '\b') {
+    line += 2;
+  }
+  if (bflag || *line == '\0' || *line == ' ')
+    *line = c;
+  else {
+    register char c1, c2, c3;
+    c1 = *++line;
+    *line++ = '\b';
+    c2 = *line;
+    *line++ = c;
+    while (c1) {
+      c3 = *line;
+      *line++ = c1;
+      c1 = c2;
+      c2 = c3;
+    }
+    lp = 0;
+    line = lbuff;
+  }
 }
 
-store (lno)
-{
-	char *malloc();
+store(lno) {
+  char *malloc();
 
-	lno %= PL;
-	if (page[lno] != 0)
-		free (page[lno]);
-	page[lno] = malloc((unsigned)strlen(lbuff) + 2);
-	if (page[lno] == 0) {
-		fprintf (stderr, "%s: no storage\n", pgmname);
-		exit (2);
-	}
-	strcpy (page[lno],lbuff);
+  lno %= PL;
+  if (page[lno] != 0)
+    free(page[lno]);
+  page[lno] = malloc((unsigned)strlen(lbuff) + 2);
+  if (page[lno] == 0) {
+    fprintf(stderr, "%s: no storage\n", pgmname);
+    exit(2);
+  }
+  strcpy(page[lno], lbuff);
 }
 
-fetch(lno)
-{
-	register char *p;
+fetch(lno) {
+  register char *p;
 
-	lno %= PL;
-	p = lbuff;
-	while (*p)
-		*p++ = '\0';
-	line = lbuff;
-	lp = 0;
-	if (page[lno])
-		strcpy (line, page[lno]);
+  lno %= PL;
+  p = lbuff;
+  while (*p)
+    *p++ = '\0';
+  line = lbuff;
+  lp = 0;
+  if (page[lno])
+    strcpy(line, page[lno]);
 }
-emit (s, lineno)
-	char *s;
-	int lineno;
+emit(s, lineno) char *s;
+int lineno;
 {
-	static int cline = 0;
-	register int ncp;
-	register char *p;
-	static int gflag = 0;
+  static int cline = 0;
+  register int ncp;
+  register char *p;
+  static int gflag = 0;
 
-	if (*s) {
-		if (gflag) {
-			putchar (SI);
-			gflag = 0;
-		}
-		while (cline < lineno - 1) {
-			putchar ('\n');
-			pcp = 0;
-			cline += 2;
-		}
-		if (cline != lineno) {
-			putchar (ESC);
-			putchar ('9');
-			cline++;
-		}
-		if (pcp)
-			putchar ('\r');
-		pcp = 0;
-		p = s;
-		while (*p) {
-			ncp = pcp;
-			while (*p++ == ' ') {
-				if ((++ncp & 7) == 0 && !xflag) {
-					pcp = ncp;
-					putchar ('\t');
-				}
-			}
-			if (!*--p)
-				break;
-			while (pcp < ncp) {
-				putchar (' ');
-				pcp++;
-			}
-			if (gflag != (*p & GREEK) && *p != '\b') {
-				if (gflag)
-					putchar (SI);
-				else
-					putchar (SO);
-				gflag ^= GREEK;
-			}
-			putchar (*p & ~GREEK);
-			if (*p++ == '\b')
-				pcp--;
-			else
-				pcp++;
-		}
-	}
+  if (*s) {
+    if (gflag) {
+      putchar(SI);
+      gflag = 0;
+    }
+    while (cline < lineno - 1) {
+      putchar('\n');
+      pcp = 0;
+      cline += 2;
+    }
+    if (cline != lineno) {
+      putchar(ESC);
+      putchar('9');
+      cline++;
+    }
+    if (pcp)
+      putchar('\r');
+    pcp = 0;
+    p = s;
+    while (*p) {
+      ncp = pcp;
+      while (*p++ == ' ') {
+        if ((++ncp & 7) == 0 && !xflag) {
+          pcp = ncp;
+          putchar('\t');
+        }
+      }
+      if (!*--p)
+        break;
+      while (pcp < ncp) {
+        putchar(' ');
+        pcp++;
+      }
+      if (gflag != (*p & GREEK) && *p != '\b') {
+        if (gflag)
+          putchar(SI);
+        else
+          putchar(SO);
+        gflag ^= GREEK;
+      }
+      putchar(*p & ~GREEK);
+      if (*p++ == '\b')
+        pcp--;
+      else
+        pcp++;
+    }
+  }
 }
 
-incr()
-{
-	store (ll++);
-	if (ll > llh)
-		llh = ll;
-	if (ll >= mustwr && page[ll%PL]) {
-		emit (page[ll%PL], ll - PL);
-		mustwr++;
-		free (page[ll%PL]);
-		page[ll%PL] = 0;
-	}
-	fetch (ll);
+incr() {
+  store(ll++);
+  if (ll > llh)
+    llh = ll;
+  if (ll >= mustwr && page[ll % PL]) {
+    emit(page[ll % PL], ll - PL);
+    mustwr++;
+    free(page[ll % PL]);
+    page[ll % PL] = 0;
+  }
+  fetch(ll);
 }
 
-decr()
-{
-	if (ll > mustwr - PL) {
-		store (ll--);
-		fetch (ll);
-	}
+decr() {
+  if (ll > mustwr - PL) {
+    store(ll--);
+    fetch(ll);
+  }
 }


### PR DESCRIPTION
## Summary
- add file and main function Doxygen comments for assorted `src/cmd` utilities
- modernize `main` signatures to use `int main(int argc, char **argv)`
- run `clang-format` on each updated file

## Testing
- `make` *(fails: gethbyname.c compile errors)*
- `doxygen docs/Doxyfile` *(fails: command not found)*
- `sphinx-build -b html docs/sphinx docs/sphinx/_build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461a485e3c833185a4f772fcbed95b

## Summary by Sourcery

Add minimal Doxygen comments to assorted command-line utilities, update their `main` signatures to modern form, and apply `clang-format` to normalize code formatting.

Enhancements:
- Add `@file` and brief Doxygen comments to multiple utilities under `src/cmd`
- Modernize all `main` functions to use `int main(int argc, char **argv)`
- Reformat code in updated files using `clang-format` for consistent style