### PR TITLE
Add x86_64 cross-compile deps

### DIFF
--- a/docs/pdp11-lab.md
+++ b/docs/pdp11-lab.md
@@ -109,4 +109,24 @@ This toolchain produces PDP-11 binaries that can be transferred to the emulator 
 Run `scripts/setup_lab.sh` to install packages, including build dependencies for
 the cross toolchain, and download the OS media automatically.
 
+## 8. Host x86_64 Cross-Compilation and Virtualization
+
+Additional packages enable testing x86_64 programs built from the Ultrix
+environment.
+
+Install the tools with:
+
+```bash
+sudo apt install --yes nasm gcc-multilib
+```
+
+For QEMU-based x86_64 emulation also run:
+
+```bash
+sudo apt install --yes qemu-system-x86
+```
+
+Setting the environment variable `INSTALL_QEMU=1` when executing
+`scripts/setup_lab.sh` installs QEMU automatically.
+
 

--- a/scripts/setup_lab.sh
+++ b/scripts/setup_lab.sh
@@ -12,10 +12,18 @@ sudo apt update
 
 # Base build stack
 sudo apt install -y \
-	build-essential cmake git pkg-config \
-	libreadline-dev libpcap-dev zlib1g-dev \
-	flex bison \
-	libgmp-dev libmpfr-dev texinfo file
+        build-essential cmake git pkg-config \
+        libreadline-dev libpcap-dev zlib1g-dev \
+        flex bison \
+        libgmp-dev libmpfr-dev texinfo file
+
+# Tools required for x86_64 cross-compilation
+sudo apt install -y nasm gcc-multilib
+
+# Optional QEMU virtualization for x86_64 tests
+if [[ "${INSTALL_QEMU:-0}" -eq 1 ]]; then
+    sudo apt install -y qemu-system-x86
+fi
 
 # SIMH emulator
 sudo apt install -y simh


### PR DESCRIPTION
## Summary
- extend setup script with nasm, gcc-multilib and optional QEMU
- document x86_64 cross tool packages in PDP-11 lab instructions

## Testing
- `make` *(fails: missing headers for build)*
- `doxygen docs/Doxyfile`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`

------
https://chatgpt.com/codex/tasks/task_e_68461a789fc88331b5d2eb1e14e492f3

## Summary by Sourcery

Add support for x86_64 cross-compilation by installing nasm and gcc-multilib, introduce optional QEMU virtualization in the setup script, and document these prerequisites in the PDP-11 lab instructions.

New Features:
- Install nasm and gcc-multilib in the setup script to enable x86_64 cross-compilation
- Introduce an optional QEMU installation controlled by the INSTALL_QEMU environment variable
- Document x86_64 cross-compilation and virtualization steps in the PDP-11 lab guide