### PR TITLE
Document new arch folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 The Ultrix-11 3.1 source code.
 
+## Source Layout
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/`    | Userland utilities |
+| `sys/`    | Kernel sources |
+| `usr/`    | User programs and libraries |
+| `arch/`   | Architecture-specific code |
+| `etc/`    | Configuration files and scripts |
+| `docs/`   | Project documentation |
+
 ## Building
 
 The repository uses a unified Makefile system. Run `make` to build both the

--- a/arch/README.md
+++ b/arch/README.md
@@ -1,0 +1,7 @@
+# Architecture Sources
+
+This directory contains architecture-specific components used by the Ultrix-11 build system.
+
+| File | Purpose |
+|------|---------|
+| `pdp11.md` | Notes on PDP-11 support. |

--- a/arch/pdp11.md
+++ b/arch/pdp11.md
@@ -1,0 +1,3 @@
+# PDP-11 Platform Notes
+
+This file collects details about the PDP-11 hardware environment used for building and running Ultrix-11.

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,5 +1,5 @@
 # Doxygen configuration for Ultrix-11 source tree
-# Scans `src/` and `sys/` directories for documentation comments.
+# Scans `src/`, `sys/`, and the new `arch/` directory for documentation comments.
 # Generated for documentation build via `doxygen`.
 
 PROJECT_NAME           = "Ultrix-11"
@@ -7,7 +7,7 @@ PROJECT_BRIEF          = "Historic UNIX source code"
 OUTPUT_DIRECTORY       = docs/doxygen
 GENERATE_LATEX         = NO
 GENERATE_XML           = YES
-INPUT                  = src sys
+INPUT                  = src sys arch
 FILE_PATTERNS          = *.c *.h
 RECURSIVE              = YES
 EXTRACT_ALL            = YES

--- a/docs/sphinx/overview.rst
+++ b/docs/sphinx/overview.rst
@@ -12,8 +12,67 @@ Source Layout
 * ``src`` – userland utilities.
 * ``sys`` – kernel sources.
 * ``usr`` – user programs and libraries.
+* ``arch`` – architecture-specific sources.
 * ``etc`` – configuration files and scripts.
 * ``docs`` – documentation for developers and users.
 
 The ``Makefile`` at the repository root coordinates building the
 sources.  See :doc:`build_steps` for detailed build instructions.
+
+src
+---
+
+.. list-table:: Key components
+   :header-rows: 1
+
+   * - File
+     - Purpose
+   * - ``cmd/ac.c``
+     - Accounting utility for process usage
+   * - ``libc``
+     - Standard C library sources
+   * - ``libF77``
+     - Fortran runtime library
+
+sys
+---
+
+.. list-table:: Key components
+   :header-rows: 1
+
+   * - File
+     - Purpose
+   * - ``conf/param.c``
+     - Kernel parameter definitions
+   * - ``dev/cons.c``
+     - Console device driver
+   * - ``net/if.c``
+     - Generic network interface code
+
+usr
+---
+
+.. list-table:: Key components
+   :header-rows: 1
+
+   * - File
+     - Purpose
+   * - ``include``
+     - Header files installed for users
+   * - ``lib``
+     - Libraries linked by applications
+   * - ``local``
+     - Optional site utilities
+
+arch
+----
+
+.. list-table:: Key components
+   :header-rows: 1
+
+   * - File
+     - Purpose
+   * - ``README.md``
+     - Overview of architecture-specific sources
+   * - ``pdp11.md``
+     - Notes on the PDP-11 platform

--- a/docs/sphinx/repository_overview.rst
+++ b/docs/sphinx/repository_overview.rst
@@ -9,8 +9,67 @@ Directories
 * ``src`` – userland utilities.
 * ``sys`` – kernel sources.
 * ``usr`` – user programs and libraries.
+* ``arch`` – architecture-specific sources.
 * ``etc`` – configuration files and scripts.
 * ``docs`` – documentation for developers and users.
+
+src
+---
+
+.. list-table:: Key components
+   :header-rows: 1
+
+   * - File
+     - Purpose
+   * - ``cmd/ac.c``
+     - Accounting utility for process tracking
+   * - ``libc``
+     - Standard C library sources
+   * - ``libF77``
+     - Fortran runtime support
+
+sys
+---
+
+.. list-table:: Key components
+   :header-rows: 1
+
+   * - File
+     - Purpose
+   * - ``conf/param.c``
+     - Kernel parameters
+   * - ``dev/cons.c``
+     - Console driver
+   * - ``net/if.c``
+     - Network interface routines
+
+usr
+---
+
+.. list-table:: Key components
+   :header-rows: 1
+
+   * - File
+     - Purpose
+   * - ``include``
+     - Exported header files
+   * - ``lib``
+     - Libraries for user applications
+   * - ``local``
+     - Site-specific programs
+
+arch
+----
+
+.. list-table:: Key components
+   :header-rows: 1
+
+   * - File
+     - Purpose
+   * - ``README.md``
+     - Overview of architecture sources
+   * - ``pdp11.md``
+     - PDP-11 platform notes
 
 Top-Level Build
 ---------------


### PR DESCRIPTION
## Summary
- document repository structure
- add new `arch` folder for architecture-specific notes
- include notes about the PDP-11 platform
- update Doxygen inputs with `arch`

## Testing
- `doxygen docs/Doxyfile`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`
- `make` *(fails: missing headers and build tools)*

------
https://chatgpt.com/codex/tasks/task_e_68461a8624c483318f24130d1eddb3c6