### PR TITLE
Add Doxygen comments for atoi

### DIFF
--- a/src/libc/gen/atoi.c
+++ b/src/libc/gen/atoi.c
@@ -1,34 +1,50 @@
 
 /**********************************************************************
  *   Copyright (c) Digital Equipment Corporation 1984, 1985, 1986.    *
- *   All Rights Reserved. 					      *
+ *   All Rights Reserved.                                             *
  *   Reference "/usr/src/COPYRIGHT" for applicable restrictions.      *
  **********************************************************************/
 
 /*
- * SCCSID: @(#)atoi.c	3.0	4/22/86
+ * SCCSID: @(#)atoi.c   3.0     4/22/86
  */
-atoi(p)
-register char *p;
-{
-	register int n;
-	register int f;
 
-	n = 0;
-	f = 0;
-	for(;;p++) {
-		switch(*p) {
-		case ' ':
-		case '\t':
-			continue;
-		case '-':
-			f++;
-		case '+':
-			p++;
-		}
-		break;
-	}
-	while(*p >= '0' && *p <= '9')
-		n = n*10 + *p++ - '0';
-	return(f? -n: n);
+/**
+ * @file atoi.c
+ * @brief Implementation of ASCII to integer conversion.
+ *
+ * Provides the classic `atoi` routine that converts a string of decimal digits,
+ * with optional leading whitespace and sign, into an integer.
+ */
+
+/**
+ * @brief Convert a string to an integer.
+ *
+ * Skips leading whitespace, handles an optional sign, and processes
+ * subsequent decimal digits.
+ *
+ * @param p Pointer to the null-terminated string to convert.
+ * @return Converted integer value.
+ */
+int atoi(register char *p) {
+  register int n; /* Accumulated result */
+  register int f; /* Sign flag: non-zero if '-' sign */
+
+  n = 0;         /* Initialize result */
+  f = 0;         /* Assume positive */
+  for (;; p++) { /* Process optional sign and whitespace */
+    switch (*p) {
+    case ' ':
+    case '\t':
+      continue; /* Skip whitespace */
+    case '-':
+      f++; /* Remember negative sign */
+    case '+':
+      p++; /* Skip sign character */
+    }
+    break; /* End sign processing */
+  }
+  while (*p >= '0' && *p <= '9')
+    n = n * 10 + *p++ - '0'; /* Accumulate digits */
+  return (f ? -n : n);       /* Apply sign and return */
 }


### PR DESCRIPTION
## Summary
- add top-level module description for `atoi.c`
- document `atoi()` with a Doxygen block
- annotate code with explanatory comments

## Testing
- `make` *(fails: incompatible legacy sources)*
- `doxygen docs/Doxyfile` *(fails: `dot` not found and many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684e6297e5d48331bd544fdcfd16970d

## Summary by Sourcery

Document the `atoi` implementation by adding Doxygen module and function comments and inline explanatory annotations

Enhancements:
- Annotate code logic with inline comments to clarify whitespace, sign handling, and digit accumulation

Documentation:
- Add Doxygen module-level description and function documentation to `atoi.c`