### PR TITLE
Fix default ARCH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@
 CC ?= cc
 # Compiler flags for C sources
 CFLAGS ?= -O2
-# Target architecture (defaults to PDP-11 for historical builds)
+# Target architecture used for the build
+# Defaults to PDP-11 for historical compatibility. Override on the
+# command line for other architectures, e.g. `ARCH=x86_64_v1`.
 ARCH ?= pdp11
 # Assembler used for assembly sources
 AS ?= as
 # Additional linker flags
 LDFLAGS ?=
-ARCH ?= x86_64_v1
 
 export CC CFLAGS AS LDFLAGS ARCH
 


### PR DESCRIPTION
## Summary
- clarify the default ARCH in `Makefile`
- remove duplicate `ARCH` assignment

## Testing
- `make`
- `make userland`
- `make kernel`
- `doxygen docs/Doxyfile`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`


------
https://chatgpt.com/codex/tasks/task_e_684e629f5534833185c59d4f7131bd20

## Summary by Sourcery

Clarify the default target architecture in the Makefile and remove the redundant ARCH assignment

Enhancements:
- Clarify default ARCH description and usage guidance in Makefile comments
- Remove duplicate ARCH assignment to streamline configuration