### PR TITLE
Resolve build warnings in ac utility

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -13,5 +13,4 @@ Ultrix-11 Documentation
    emulator_setup
    emulator_lab
    usage
-   arch_x86_64_v1
    libc_dir

--- a/docs/sphinx/libc_dir.rst
+++ b/docs/sphinx/libc_dir.rst
@@ -1,5 +1,5 @@
 Directory Handling Functions
-===========================
+============================
 
 The Ultrix libc provides a traditional directory interface
 compatible with early BSD systems. Key routines include:

--- a/src/cmd/chog.c
+++ b/src/cmd/chog.c
@@ -28,8 +28,7 @@ static char Sccsid[] = "@(#)chog.c	3.0	4/21/86";
  * @param argv Argument vector.
  * @return EXIT_SUCCESS on success.
  */
-int main(int argc, char **argv) int argc;
-{
+int main(int argc, char **argv) {
   int uid, gid;
   int status = 0;
   struct passwd *pwd, *getpwnam(), *getpwuid();


### PR DESCRIPTION
## Summary
- clean up duplicate Doxygen file header in `ac.c`
- modernize time handling for `ac.c`
- remove deprecated `ftime` usage
- modernize `newday` calculation
- simplify main comment formatting
- document `ac` main parameters
- remove duplicate entry in `index.rst`
- fix title underline in `libc_dir.rst`
- modernize `chog.c` entry point

## Testing
- `make CC=clang CFLAGS="-O3 -Wall -Wextra" ARCH=x86_64_v1`
- `doxygen docs/Doxyfile` *(fails: warnings remain from other files)*
- `python -m sphinx -b html docs/sphinx docs/sphinx/_build`

------
https://chatgpt.com/codex/tasks/task_e_6887bd6f2a208331bf744c5f7bded35c

## Summary by Sourcery

Clean up and modernize the ac utility and chog command by removing deprecated APIs, standardizing time handling, updating Doxygen headers, and fixing related documentation in Sphinx

Enhancements:
- Replace deprecated ftime and sys/timeb.h usage in ac.c with time() and mktime-based calculations
- Modernize newday function in ac.c to calculate midnight using localtime_r and mktime
- Simplify and standardize Doxygen headers and main function parameter documentation in ac.c
- Update chog.c entry point to ANSI C function definition style

Documentation:
- Remove duplicate entry in index.rst and fix title underline in libc_dir.rst
- Document main parameters for ac utility and clean up comment formatting