### PR TITLE
Resolve Doxygen issues in chog

### DIFF
--- a/src/cmd/chog.c
+++ b/src/cmd/chog.c
@@ -28,8 +28,7 @@ static char Sccsid[] = "@(#)chog.c	3.0	4/21/86";
  * @param argv Argument vector.
  * @return EXIT_SUCCESS on success.
  */
-int main(int argc, char **argv) int argc;
-{
+int main(int argc, char **argv) {
   int uid, gid;
   int status = 0;
   struct passwd *pwd, *getpwnam(), *getpwuid();
@@ -61,9 +60,14 @@ int main(int argc, char **argv) int argc;
   exit(status);
 }
 
-isnumber(s) register char *s;
-{
-  while (isdigit(*s))
+/**
+ * @brief Determine if a string is composed entirely of digits.
+ *
+ * @param s String to examine.
+ * @return 1 if @p s contains only digits, otherwise 0.
+ */
+static int isnumber(const char *s) {
+  while (isdigit((unsigned char)*s))
     s++;
-  return ((*s == '\0') ? 1 : 0);
+  return (*s == '\0') ? 1 : 0;
 }

--- a/src/libc/stdio/ungetc.c
+++ b/src/libc/stdio/ungetc.c
@@ -17,8 +17,7 @@
  * @param iop Stream to modify.
  * @return The character pushed back or EOF on error.
  */
-ungetc(c, iop) register FILE *iop;
-{
+int ungetc(int c, FILE *iop) {
   if (c == EOF)
     return (EOF);
   if ((iop->_flag & _IOREAD) == 0 || iop->_ptr <= iop->_base)


### PR DESCRIPTION
## Summary
- fix K&R prototypes in `chog.c` and `ungetc.c`
- add missing Doxygen for `isnumber`
- format code with clang-format

## Testing
- `make CC=clang CFLAGS="-O3 -Wall -Wextra" ARCH=x86_64_v1`
- `doxygen docs/Doxyfile` *(fails: warnings from other files)*
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`

------
https://chatgpt.com/codex/tasks/task_e_6887bd6f2a208331bf744c5f7bded35c