### PR TITLE
Resolve build warnings in ac utility

### DIFF
--- a/src/cmd/chog.c
+++ b/src/cmd/chog.c
@@ -19,17 +19,17 @@ static char Sccsid[] = "@(#)chog.c	3.0	4/21/86";
 #include <ctype.h>
 #include <pwd.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/types.h>
 
 /**
  * @brief Program entry point.
  *
- * @param argc Argument count.
- * @param argv Argument vector.
- * @return EXIT_SUCCESS on success.
+ * @param argc Number of command line arguments.
+ * @param argv Array of argument strings.
+ * @return EXIT_SUCCESS on success, EXIT_FAILURE on error.
  */
-int main(int argc, char **argv) int argc;
-{
+int main(int argc, char **argv) {
   int uid, gid;
   int status = 0;
   struct passwd *pwd, *getpwnam(), *getpwuid();
@@ -58,12 +58,17 @@ int main(int argc, char **argv) int argc;
       status = 1;
     }
   }
-  exit(status);
+  return status;
 }
 
-isnumber(s) register char *s;
-{
-  while (isdigit(*s))
+/**
+ * @brief Determine if a string contains only digits.
+ *
+ * @param s Input string to check.
+ * @return 1 if the string is numeric, otherwise 0.
+ */
+static int isnumber(const char *s) {
+  while (isdigit((unsigned char)*s))
     s++;
-  return ((*s == '\0') ? 1 : 0);
+  return *s == '\0';
 }


### PR DESCRIPTION
## Summary
- clean up duplicate Doxygen file header in `ac.c`
- modernize time handling for `ac.c`
- remove deprecated `ftime` usage
- modernize `newday` calculation
- simplify main comment formatting
- document `ac` main parameters
- modernize `chog.c` with ANSI prototypes and Doxygen comments

## Testing
- `make CC=clang CFLAGS="-O3 -Wall -Wextra" ARCH=x86_64_v1`
- `doxygen docs/Doxyfile` *(fails: warnings remain from other files)*
- `sphinx-build -b html docs/sphinx docs/sphinx/_build` *(build succeeded with 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6887bd6f2a208331bf744c5f7bded35c