### PR TITLE
Disable dot in Doxygen

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -12,3 +12,4 @@ FILE_PATTERNS          = *.c *.h
 RECURSIVE              = YES
 EXTRACT_ALL            = YES
 QUIET                  = YES
+HAVE_DOT               = NO


### PR DESCRIPTION
## Summary
- avoid Graphviz issues during documentation generation

## Testing
- `make all ARCH=x86_64_v1`
- `doxygen docs/Doxyfile`
- `sphinx-build -b html docs/sphinx docs/sphinx/_build`


------
https://chatgpt.com/codex/tasks/task_e_688a4c1376948331a31c38f264b15e73