### PR TITLE
Maintain repo cleanliness

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -8,3 +8,6 @@ Generated directories and files are ignored via `.gitignore`:
 - `docs/doxygen/` and `docs/sphinx/_build/`
 
 Developers should run `scripts/build.sh` to compile the project.
+## Recent Cleanup
+- Removed temporary `build/` directory after compilation.
+- Deleted generated documentation under `docs/doxygen/` and `docs/sphinx/_build/`.


### PR DESCRIPTION
## Summary
- describe building with scripts in the README
- document cleanup in PROJECT_STATUS

## Testing
- `scripts/build.sh`
- `doxygen docs/Doxyfile`
- `sphinx-build -b html . _build`

------
https://chatgpt.com/codex/tasks/task_e_688a9e5296108331b21e6a7619d01b90

## Summary by Sourcery

Document the build process in the README and record cleanup steps in the project status file

Documentation:
- Add build script instructions to the README
- Document removal of temporary build/ and generated docs directories in PROJECT_STATUS.md